### PR TITLE
(SIMP-1574) Fix Forge `haveged` dependency name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,5 @@
+* Wed Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.1.1-0
+- Fix Forge `haveged` dependency name
+
 * Thu Jun 30 2016 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 0.1.0-0
 - Initial release for CentOS 7 only

--- a/metadata.json
+++ b/metadata.json
@@ -1,16 +1,20 @@
 {
   "name": "simp-libreswan",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "simp",
   "summary": "Manages IPSec VPN Tunnels",
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-libreswan",
   "project_page": "https://github.com/simp/pupmod-simp-libreswan",
   "issues_url": "https://simp-project.atlassian.net",
-  "tags": [ "simp", "pki", "ipsec" ],
+  "tags": [
+    "simp",
+    "pki",
+    "ipsec"
+  ],
   "dependencies": [
     {
-      "name": "simp/puppet-haveged",
+      "name": "simp/haveged",
       "version_requirement": ">= 0.3.0 < 1.0.0"
     },
     {


### PR DESCRIPTION
`metadata.json` erroneously claimed `simp/puppet-haveged` as a
dependency, which causes a fatal error when pushing to the Forge.

This patch corrects the dependency name  to `simp/haveged`.

SIMP-1574 #comment fixed pupmod-simp-libreswan