### PR TITLE
(SIMP-1671) Fix ipsec config bugs and enhance

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+* Wed Oct 12 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 1.0.0-0
+- Fix several bugs in the following categories:
+  - Use of wrong variables (cut and paste errors or typos)
+  - Improper parameter validations
+  - Parameters not being used in erb files.
+  - OBE names of ipsec settings.
+  - Missing quotes/braces around settings that can contain whitespace
+- Expose more ipsec settings.
+- Allow IPv6 addresses
+
 * Wed Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.1.1-0
 - Fix Forge `haveged` dependency name
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Please read our [Contribution Guide](https://simp-project.atlassian.net/wiki/dis
 
 This module is optimally designed for use within a larger SIMP ecosystem, but it can be used independently:
 * When included within the SIMP ecosystem, security compliance settings will be managed from the Puppet server.
-* If used independently, all SIMP-managed security subsystems are disabled by default and must be explicitly opted into by administrators.  Please review the `client_nets` and `$enable_*` parameters in `manifests/init.pp` for details.
-
+* If used independently, all SIMP-managed security subsystems are disabled by default and must be explicitly opted into by administrators.  Please review the the `ipsec_client_nets`, `simp_firewall`, `nssdb_password`, and
+ `use_*` parameters in `manifests/init.pp` for details.
 
 ## Module Description
 

--- a/files/usr/local/scripts/nss/update_nssdb_password.sh
+++ b/files/usr/local/scripts/nss/update_nssdb_password.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
 #  This script is called from the pupmod-simp-libreswan
-#  module.  It is used to set the password on the NSS 
+#  module.  It is used to set the password on the NSS
 #  database used by libreswan.
 #
-clean_up(){ 
+clean_up(){
   if [ -d $tmpdir ]; then
     rm -rf $tmpdir
   fi
@@ -45,10 +45,10 @@ fi
 mkdir -p $tmpdir
 # Determine the old password
 case $oldpasswd in
-[nN][oO][nN][eE]) 
+[nN][oO][nN][eE])
   echo "" > $tmpdir/op
   ;;
-*) 
+*)
   echo $oldpasswd > $tmpdir/op
   ;;
 esac

--- a/files/usr/local/scripts/nss_chpasswd.sh.erb
+++ b/files/usr/local/scripts/nss_chpasswd.sh.erb
@@ -2,7 +2,7 @@
 #
 #
 #
-clean_up(){ 
+clean_up(){
   if [[ -d $tmpdir ]]; then
     rm -rf $tmpdir
   fi

--- a/lib/puppet/parser/functions/libreswan_validate_yesno.rb
+++ b/lib/puppet/parser/functions/libreswan_validate_yesno.rb
@@ -1,0 +1,36 @@
+module Puppet::Parser::Functions
+  newfunction(:libreswan_validate_yesno, :doc => <<-'ENDHEREDOC') do |args|
+   Validate that a passed String contains 'yes' or 'no'
+   when converted to lowercase
+
+    Examples of passing values:
+
+      libreswan_validate_yesno('yes')
+      libreswan_validate_yesno('Yes')
+      libreswan_validate_yesno('YES')
+      libreswan_validate_yesno('no')
+      libreswan_validate_yesno('No')
+      libreswan_validate_yesno('NO')
+
+    The following values will fail:
+
+      libreswan_validate_yesno('true')
+      libreswan_validate_yesno('false')
+      libreswan_validate_yesno('yes', 'yes')
+
+    ENDHEREDOC
+
+    if (args.length != 1)
+      raise Puppet::ParseError,('libreswan_validate_yesno(): Must pass a string.')
+    end
+
+    unless (args[0].is_a?(String))
+      raise Puppet::ParseError,("libreswan_validate_yesno(): arg must be a String")
+    end
+
+    if (args[0].downcase.strip != 'yes' and args[0].downcase.strip != 'no')
+      raise Puppet::ParseError,("libreswan_validate_yesno(): '#{args[0]}' is not 'yes' or 'no'")
+    end
+
+  end
+end

--- a/manifests/add_connection.pp
+++ b/manifests/add_connection.pp
@@ -1,27 +1,25 @@
-# Define to set up connection files in the ipsec
+# Define to create a connection file in the ipsec configuration
 # directory. The name of the connection must be unique.
 #
-# You can can set up defaults for your connections by using the name
-# default. This will create a file default.conf with a conn %default
-# header and all settings will be used as defaults for any connection.
+# You can can set up defaults for all of your connections by using the
+# name 'default'. This will create a file default.conf with a
+# 'conn %default' header.  Then, all settings in default.conf will be
+# used as defaults for connections specified in other files.
 #
-# Not all settings from libreswan that are available for connections
-# are defined here. A connection can also be created by placing a file
-# in the correct format in the ipsec directory and giving it a .conf suffix.
+# Not all available, connection-related, libreswan settings are defined
+# here. However, should you need a missing setting you can manually
+# create a correctly-formatted, connection configuration file in the
+# ipsec configuration directory.  This file must have a ".conf" suffix.
 #
-# @param dir [AbsolutePath] The absolute path to the IPSEC directory.
-#   All the other parameters are possible values for the "conn" section
-#   in the ipsec configuration. You can define as many different
-#   connects as needed.
+# NOTE: Manually generated configuration files are not managed by Puppet.
 #
-#   Read the Libreswan Documentation for details of the settings
-#   https://libreswan.org/man/ipsec.conf.5.html the
-#      CONN:SETTINGS section
+# @param dir [AbsolutePath] The absolute path to the ipsec configuration
+# directory.
 #
-#   The following settings, because they have defaults other than
-#   what was set in libreswan will always appear in a connection file.
-#   you can still override the defaults by passing in different data
-#   in the definition parameters.
+# The following parameters correspond to libreswan settings for which
+# the default values are different from the libreswan defaults. You
+# can override the defaults by passing in different data in the
+# definition parameters.
 #
 # @param keyingtries [Integer] The number of times a connection will try to
 #    reconnect before exiting.
@@ -31,44 +29,19 @@
 #
 # @param phase2alg [String] the ciphers used in the second part of the connection.
 #
-# The rest of the parameters are undef. See Libreswan documentation
-# or defaults and definitions.
+# The rest of the parameters map one-to-one to libreswan settings and
+# are undef. Any undef parameter will not appear in the generated
+# configuration file for the connection. See libreswan documentation for
+# the setting defaults when omitted from a connection's configuration.
+#   https://libreswan.org/man/ipsec.conf.5.html, the CONN:SETTINGS section
 #
-# @param authby [Undef]
-# @param auto [Undef]
-# @param connaddrfamily [Undef]
-# @param left [String] The IP Address of the local connection.
-# @param left [Undef]
-# @param leftca [Undef]
-# @param leftcert [Undef]
-# @param leftid [Undef]
-# @param leftprotoport [Undef]
-# @param leftrsasigkey [Undef]
-# @param leftsendcert [Undef]
-# @param leftsourceip [Undef]
-# @param leftsubnet [Undef]
-# @param leftsubnets [Undef]
-# @param leftupdown [Undef]
-# @param phase2 [Undef]
-# @param phase2alg [Undef]
-# @param rightsendcert [Undef]
-# @param right [Undef]
-# @param rightca [Undef]
-# @param rightcert [Undef]
-# @param rightid [Undef]
-# @param rightprotoport [Undef]
-# @param rightrsasigkey [Undef]
-# @param rightsourceip [Undef]
-# @param rightsubnet [Undef]
-# @param rightsubnets [Undef]
-# @param rightupdown [Undef]
-# @param type [String] The type of connection: passthrough, tunnel
 #
 define libreswan::add_connection (
   $dir                = '/etc/ipsec.d',
   $keyingtries        = '10',
   $ike                = 'aes-sha2;dh24',
   $phase2alg          = 'aes-sha2;dh24',
+  # TODO reorder parameters more logically
   $left               = undef,
   $right              = undef,
   $connaddrfamily     = undef,
@@ -104,7 +77,7 @@ define libreswan::add_connection (
   $ikev2              = undef,
   $phase2             = undef,
   $ikepad             = undef,
-  $ike_frag           = undef,
+  $fragmentation      = undef,
   $sha2_truncbug      = undef,
   $narrowing          = undef,
   $sareftrack         = undef,
@@ -129,15 +102,16 @@ define libreswan::add_connection (
 ) {
   include 'libreswan'
 
-  case $right {
-    undef  :  {}
-    '%any' :  {}
-    '%defaultroute' :  {}
-    '%opportunistic' :  {}
-    '%opportunisticgroup' :  {}
-    '%group' :  {}
-    default  :  {validate_ipv4_address($right)}
-  }
+  # TODO reorder validations more logically
+
+  #TODO left/right validations do not allow magic values to identify an
+  # interface: %<interface name>, e.g. %eth0
+  #TODO validate is a valid IP addr but not a masked routing address
+  #TODO when validate_net_list() regex logic is fixed....
+  # if $left {
+  #   validate_string
+  #   validate_net_list($left, '^(%any|%defaultroute|%opportunistic|%opportunisticgroup|%group)$)')
+  # }
   case $left {
     undef  :  {}
     '%any' :  {}
@@ -145,71 +119,150 @@ define libreswan::add_connection (
     '%opportunistic' :  {}
     '%opportunisticgroup' :  {}
     '%group' :  {}
-    default :  {validate_ipv4_address($left)}
+    default  :  {
+      validate_string($left) # must be single IP address
+      validate_net_list($left)
+    }
   }
-  case $leftprotoport {
-    undef  : {}
-    '%any' : {}
-    default : { validate_port($leftprotoport)}
+  #TODO when validate_net_list() regex logic is fixed....
+  # if $right {
+  #   validate_string
+  #   validate_net_list($right, '^(%any|%defaultroute|%opportunistic|%opportunisticgroup|%group)$)')
+  # }
+  case $right {
+    undef  :  {}
+    '%any' :  {}
+    '%defaultroute' :  {}
+    '%opportunistic' :  {}
+    '%opportunisticgroup' :  {}
+    '%group' :  {}
+    default :  {
+      validate_string($right) # must be single IP address
+      validate_net_list($right)
+    }
   }
-  case $rightprotoport {
-    undef  : {}
-    '%any' : {}
-    default : { validate_port($rightprotoport)}
+
+  # TODO Create custom validator to allow following types of permutations:
+  #   *protoport=17   *protoport=17/1701  *protoport=17/%any  *protoport=tcp
+  #   *protoport=tcp/22  *protoport=tcp/%any
+  if $leftprotoport { validate_string($leftprotoport)}
+  if $rightprotoport { validate_string($rightprotoport)}
+
+  #TODO validate is a valid IP addr but not a masked routing address
+  if $leftsourceip {
+    validate_string($leftsourceip)
+    validate_net_list($leftsourceip)
   }
-  if $leftsourceip       { validate_ipv4_address($leftsourceip)}
-  if $rightsourceip      { validate_ipv4_address($rightsourceip)}
+  if $rightsourceip {
+    validate_string($rightsourceip)
+    validate_net_list($rightsourceip)
+  }
   if $leftupdown         { validate_string($leftupdown)}
   if $rightupdown        { validate_string($rightupdown)}
-  if $authby             { validate_array_member($authby, ['rsasig','secrets'])}
+  if $authby             { validate_array_member($authby, ['rsasig','secret', 'secret|rsasig', 'never', 'null'])}
   if $auto               { validate_array_member($auto, ['add','start','ondemand','ignore'])}
   if $leftcert           { validate_string($leftcert)}
   if $rightcert          { validate_string($rightcert)}
-  if $leftrsasigkey      { validate_array_member($leftrsasigkey, ['%cert','%none','%dns','%dnsonload','%dnsondemand'])}
-  if $leftrsasigkey2     { validate_array_member($leftrsasigkey2, ['%cert','%none','%dns','%dnsonload','%dnsondemand'])}
-  if $rightrsasigkey     { validate_array_member($rightrsasigkey, ['%cert','%none','%dns','%dnsonload','%dnsondemand'])}
-  if $rightrsasigkey2    { validate_array_member($rightrsasigkey2, ['%cert','%none','%dns','%dnsonload','%dnsondemand'])}
-  if $leftsendcert       { validate_array_member($leftsendcert, ['yes','no','never','always','ifasked'])}
-  if $rightsendcert      { validate_array_member($rightsendcert, ['yes','no','never','always','ifasked'])}
+  if $leftrsasigkey      { validate_string($leftrsasigkey) }
+  if $leftrsasigkey2     { validate_string($leftrsasigkey2) }
+  if $rightrsasigkey     { validate_string($rightrsasigkey) }
+  if $rightrsasigkey2    { validate_string($rightrsasigkey2) }
+  if $leftsendcert       { validate_array_member($leftsendcert, ['yes','no','never','always','sendifasked'])}
+  if $rightsendcert      { validate_array_member($rightsendcert, ['yes','no','never','always','sendifasked'])}
   if $leftid             { validate_string($leftid)}
   if $rightid            { validate_string($rightid)}
   if $leftca             { validate_string($leftca)}
   if $rightca            { validate_string($rightca)}
-  if $connaddrfamily     { validate_re($connaddrfamily,'^(ipv4|ipv6)$',"${ connaddrfamily} is not supported for hidetos") }
+  if $connaddrfamily     { validate_re($connaddrfamily,'^(ipv4|ipv6)$',"${connaddrfamily} is not supported for connaddrfamily") }
   if $type               { validate_array_member($type, ['tunnel','transport','passthough','reject','drop'])}
-  if $leftsubnets        { validate_net_list($leftsubnets)}
-  if $rightsubnets       { validate_net_list($rightsubnets)}
-  if $leftsubnet         { validate_net_list($leftsubnet)}
-  if $rightsubnet        { validate_net_list($rightsubnet)}
-  if $leftaddresspool    { validate_net_list($leftaddresspool)}
-  if $rightaddresspool   { validate_net_list($rightaddresspool)}
-  if $leftnexthop        { validate_ipv4_address($leftnexthop)}
-  if $rightnexthop       { validate_ipv4_address($rightnexthop)}
+
+  # *subnets can be a single value in a String or multiple values in an Array
+  if $leftsubnets        { validate_net_list($leftsubnets) }
+  if $rightsubnets       { validate_net_list($rightsubnets) }
+
+  if $leftsubnet         {
+    validate_string($leftsubnet)  # Single CIDR
+    validate_net_list($leftsubnet, '(vhost:|vnet:|%priv|%no)') #WARNING regex doesn't work yet
+  }
+  if $rightsubnet        {
+    validate_string($rightsubnet) # Single CIDR
+    validate_net_list($rightsubnet, '(vhost:|vnet:|%priv|%no)') #WARNING regex doesn't work yet
+  }
+
+  # *addresspool is really supposed to be only 2 IP address values in an Array
+  #TODO validate full IP addresses (CIDR notation not allowed)
+  #TODO validation Array length is 2
+  #
+  if $leftaddresspool {
+    validate_array($leftaddresspool)
+    validate_net_list($leftaddresspool)
+  }
+  if $rightaddresspool {
+    validate_array($rightaddresspool)
+    validate_net_list($rightaddresspool)
+  }
+
+  #TODO when validate_net_list() regex logic is fixed....
+  # if $leftnexthop {
+  #   validate_string
+  #   validate_net_list($leftnexthop, '^(%direct|%defaultroute)$)')
+  # }
+  case $leftnexthop {
+    undef           : {}
+    '%direct'       : {}
+    '%defaultroute' : {}
+    default         : {
+      validate_string($leftnexthop)
+      validate_net_list($leftnexthop)
+    }
+  }
+
+  #TODO when validate_net_list() regex logic is fixed....
+  # if $rightnexthop {
+  #   validate_string
+  #   validate_net_list($rightnexthop, '^(%direct|%defaultroute)$)')
+  # }
+  case $rightnexthop {
+    undef           : {}
+    '%direct'       : {}
+    '%defaultroute' : {}
+    default         : {
+      validate_string($rightnexthop)
+      validate_net_list($rightnexthop)
+    }
+  }
+
   if $ikev2              { validate_array_member($ikev2, ['insist','permit','propose','never','yes', 'no'])}
-  if $ikepad             { validate_re($ikepad,'^(yes|no)$',"${ ikepad} is not supported for ikepad") }
-  if $narrowing          { validate_re($narrowing,'^(yes|no)$',"${ narrowing} is not supported for narrowing") }
-  if $sha2_truncbug      { validate_re($sha2_truncbug,'^(yes|no)$',"${ sha2_truncbug} is not supported for sha2_truncbug") }
-  if $nat_ikev1_method   { validate_array_member($nat_ikev1_method, ['draft','rfc','both'])}
-  if $ike_frag           { validate_array_member($ike_frag, ['yes','no','force'])}
+  if $ikepad             { libreswan_validate_yesno($ikepad) }
+  if $narrowing          { libreswan_validate_yesno($narrowing) }
+  if $phase2             { validate_array_member($phase2, ['esp', 'ah'])}
+  if $sha2_truncbug      { libreswan_validate_yesno($sha2_truncbug) }
+  if $nat_ikev1_method   { validate_array_member($nat_ikev1_method, ['drafts','rfc','both'])}
+  if $fragmentation      { validate_array_member($fragmentation, ['yes','no','force'])}
   if $sareftrack         { validate_array_member($sareftrack, ['yes','no','conntrack'])}
-  if $leftxauthserver    { validate_re($leftxauthserver,'^(yes|no)$',"${ leftxauthserver} is not supported for leftxauthserver") }
-  if $rightxauthserver   { validate_re($rightxauthserver,'^(yes|no)$',"${ rightxauthserver} is not supported for rightxauthserver") }
-  if $leftxauthusername  { validate_re($leftxauthusername,'^(yes|no)$',"${ leftxauthusername} is not supported for leftxauthusername") }
-  if $rightxauthusername { validate_re($rightxauthusername,'^(yes|no)$',"${ rightxauthusername} is not supported for rightxauthusername") }
-  if $leftxauthclient    { validate_re($leftxauthclient,'^(yes|no)$',"${ leftxauthclient} is not supported for leftxauthclient") }
-  if $rightxauthclient   { validate_re($rightxauthclient,'^(yes|no)$',"${ rightxauthclient} is not supported for rightxauthclient") }
-  if $leftmodecfgserver  { validate_re($leftmodecfgserver,'^(yes|no)$',"${ leftmodecfgserver} is not supported for leftmodecfgserver") }
-  if $rightmodecfgserver { validate_re($rightmodecfgserver,'^(yes|no)$',"${ rightmodecfgserver} is not supported for rightmodecfgserver") }
-  if $leftmodecfgclient  { validate_re($leftmodecfgclient,'^(yes|no)$',"${ leftmodecfgclient} is not supported for leftmodecfgclient") }
-  if $rightmodecfgclient { validate_re($rightmodecfgclient,'^(yes|no)$',"${ rightmodecfgclient} is not supported for rightmodecfgclient") }
-  if $xauthby            { validate_array_member($xauthby, ['file','pam','alwaysok'])}
-  if $xauthfail          { validate_array_member($xauthby, ['hard','soft'])}
-  if $modecfgpull        { validate_re($modecfgpull,'^(yes|no)$',"${ modecfgpull} is not supported for modecfgpull") }
-  if $modecfgdns1        { validate_ipv4_address($modecfgdns1)}
-  if $modecfgdns2        { validate_ipv4_address($modecfgdns2)}
+  if $leftxauthserver    { libreswan_validate_yesno($leftxauthserver) }
+  if $rightxauthserver   { libreswan_validate_yesno($rightxauthserver) }
+  if $leftxauthusername  { validate_string($leftxauthusername) }
+  if $rightxauthusername { validate_string($rightxauthusername) }
+  if $leftxauthclient    { libreswan_validate_yesno($leftxauthclient) }
+  if $rightxauthclient   { libreswan_validate_yesno($rightxauthclient) }
+  if $leftmodecfgserver  { libreswan_validate_yesno($leftmodecfgserver) }
+  if $rightmodecfgserver { libreswan_validate_yesno($rightmodecfgserver) }
+  if $leftmodecfgclient  { libreswan_validate_yesno($leftmodecfgclient) }
+  if $rightmodecfgclient { libreswan_validate_yesno($rightmodecfgclient) }
+  if $xauthby            { validate_array_member($xauthby, ['file','pam','alwaysok']) }
+  if $xauthfail          { validate_array_member($xauthfail, ['hard','soft']) }
+  if $modecfgpull        { libreswan_validate_yesno($modecfgpull) }
+  if $modecfgdns1        {
+    validate_string($modecfgdns1)
+    validate_net_list($modecfgdns1)
+  }
+  if $modecfgdns2        {
+    validate_string($modecfgdns2)
+    validate_net_list($modecfgdns2)
+  }
   if $modecfgdomain      { validate_string($modecfgdomain)}
   if $modecfgbanner      { validate_string($modecfgbanner)}
-
 
   validate_string($phase2alg)
   validate_string($ike)

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,24 +7,47 @@ class libreswan::config {
   # set up the /etc/ipsec.conf file and any directories that
   # might be defined in it.
   # have to copy variables local because scope and scope.lookup don't work
-  # in if statements.
+  # in erb if statements.
   $myid                = $::libreswan::myid
+  $protostack          = $::libreswan::protostack
   $interfaces          = $::libreswan::interfaces
   $listen              = $::libreswan::listen
+  $ikeport             = $::libreswan::ikeport
+  $nflog_all           = $::libreswan::nflog_all
+  $nat_ikeport         = $::libreswan::nat_ikeport
   $keep_alive          = $::libreswan::keep_alive
+  $virtual_private     = $::libreswan::virtual_private
   $myvendorid          = $::libreswan::myvendorid
   $nhelpers            = $::libreswan::nhelpers
+#seedbits
+#secctx-attr-type
   $plutofork           = $::libreswan::plutofork
   $crlcheckinterval    = $::libreswan::crlcheckinterval
   $strictcrlpolicy     = $::libreswan::strictcrlpolicy
+  $ocsp_enable         = $::libreswan::ocsp_enable
+  $ocsp_strict         = $::libreswan::ocsp_strict
+  $ocsp_timeout        = $::libreswan::ocsp_timeout
+  $ocsp_uri            = $::libreswan::ocsp_uri
+  $ocsp_trustname      = $::libreswan::ocsp_trustname
   $syslog              = $::libreswan::syslog
+  $klipsdebug          = $::libreswan::klipsdebug
+  $plutodebug          = $::libreswan::plutodebug
   $uniqueids           = $::libreswan::uniqueids
   $plutorestartoncrash = $::libreswan::plutorestartoncrash
-  $plutostderrlog      = $::libreswan::plutostderrlog
-  $plutostderrlogtime  = $::libreswan::plutostderrlogtime
-  $force_busy          = $::libreswan::force_busy
+  $logfile             = $::libreswan::logfile
+  $logappend           = $::libreswan::logappend
+  $logtime             = $::libreswan::logtime
+  $ddos_mode           = $::libreswan::ddos_mode
+  $ddos_ike_treshold   = $::libreswan::ddos_ike_treshold
+#max-halfopen-ike         = $::libreswan::
+#shuntlifetime         = $::libreswan::
+#xfrmlifetime         = $::libreswan::
+  $dumpdir             = $::libreswan::dumpdir
   $statsbin            = $::libreswan::statsbin
+  $ipsecdir            = $::libreswan::ipsecdir
+  $secretsfile         = $::libreswan::secretsfile
   $perpeerlog          = $::libreswan::perpeerlog
+  $perpeerlogdir       = $::libreswan::perpeerlogdir
   $fragicmp            = $::libreswan::fragicmp
   $hidetos             = $::libreswan::hidetos
   $overridemtu         = $::libreswan::overridemtu
@@ -42,8 +65,8 @@ class libreswan::config {
     mode   => '0700',
     before => File['/etc/ipsec.conf']
   }
-  if $::libreswan::plutostderrlog {
-    file {$::libreswan::plutostderrlog:
+  if $::libreswan::logfile {
+    file {$::libreswan::logfile:
       ensure => file,
       owner  => root,
       mode   => '0600',

--- a/manifests/config/pki/nsspki.pp
+++ b/manifests/config/pki/nsspki.pp
@@ -1,6 +1,5 @@
-# This class will ensure that the
-# the PKI certificates are loaded into the NSS Database used
-# by the IPSEC process.
+# This class will ensure that the PKI certificates are loaded into the
+# NSS Database used by the IPSEC process.
 # It is called when the certificates change or when the data
 # base is initialized.
 #
@@ -12,8 +11,8 @@ class libreswan::config::pki::nsspki {
   $key    = "${::libreswan::certsource}/pki/private/${::fqdn}.pem"
 
 
-  # Currently for version 3.15 the secrets file must be updated with
-  # name of the certificate to use from the NSS database.
+  # Currently for libreswan version 3.15 the secrets file must be
+  # updated with name of the certificate to use from the NSS database.
   file { $::libreswan::secretsfile:
     ensure  => file,
     owner   => root,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# Module 'libreswan' installs and configures libreswan for use with IPSEC
+# Module 'libreswan' installs and configures libreswan to provide IPsec
 # tunnels. It is very important you read the documentation that comes with
 # libreswan before attempting to use this module.
 #
@@ -16,7 +16,7 @@
 # It will also configure and maintain the NSS database used by ipsec if you have
 # chosen to let simp manage your PKI certificates.
 #
-# To add and start tunnels that will be managed by the ipsec service see the module
+# To add and start tunnels that will be managed by the ipsec service see the manifest
 # libreswan::add_connection.
 # ---
 #
@@ -28,52 +28,41 @@
 #
 # * If used independently, all SIMP-managed security subsystems are disabled by
 #   default, and must be explicitly opted into by administrators. Please review
-#   the +client_nets+ and +$enable_*+ parameters for details.
+#   the +ipsec_client_nets+, +simp_firewall+, +nssdb_password+, and +$use_*+
+#   parameters for details.
 #
 #
 # @param service_name [String] The name of the ipsec service.
 #
 # @param package_name [String] The name of the libreswan package.
 #
-# @param client_nets [Array] A whitelist of subnets (in CIDR notation) permitted access.
+# @param ipsec_client_nets [Array] A whitelist of subnetworks (in CIDR notataion) with
+# permitted acccess explicitly for ipsec communication
+#
+# @param simp_firewall [Boolean] Whether to add appropriate rules to
+#  allow ipsec traffic to the SIMP-controlled firewall
+#
+# @param use_simp_pki [Boolean] Whether to use SIMP's PKI infrastructure to
+#  manage certificates used by ipsec
+#
+# @param use_fips [Boolean] Whether server is in FIPS mode.  Affects digest algorithms
+# allowed to be used by ipsec.
+#
+# @param use_haveged [Boolean] Whether to use haveged to ensure adequate entropy
+#
+# @param nssdb_password [String] Password for the NSS database used by ipsec
 #
 # @param certsource [AbsolutePath] Used if use_simp_pki is true to copy certs locally for ipsec.
 #
-# @param ipsecdir [AbsolutePath] The directory to store all IPSEC configuration information.
+# @param ipsecdir [AbsolutePath] The directory to store all ipsec configuration information.
 #
 # The other parameters are all setting for the ipsec.conf file. See the
-# Libreswan doumentation https://libreswan.org/man/ipsec.conf.5.html
-# for more information reguarding these variables.
+# libreswan doumentation https://libreswan.org/man/ipsec.conf.5.html
+# for more information regarding these variables.
 # Any variable set to undefined will not appear in the configuration
-# file and will default to the value set by Libreswan. Those set will
+# file and will default to the value set by libreswan. Those set will
 # appear in the configuration file but can be over written using the
 # hiera yaml files.
-#
-# @param ikeport [Undef]
-# @param nat_ikeport [Undef]
-# @param keep_alive [Undef]
-# @param virtual_private [Undef]
-# @param myvendorid [Undef]
-# @param nhelpers [Undef]
-# @param plutofork [Undef]
-# @param crlcheckinterval [Undef]
-# @param strictcrlpolicy [Undef]
-# @param syslog [Undef]
-# @param klipsdebug [Undef]
-# @param plutodebug [Undef]
-# @param uniqueids [Undef]
-# @param plutorestartoncrash [Undef]
-# @param plutostderrlog [Undef]
-# @param plutostderrlogtime [Undef]
-# @param force_busy [Undef]
-# @param dumpdir [Undef]
-# @param statsbin [Undef]
-# @param secretsfile [Undef]
-# @param perpeerlog [Undef]
-# @param perpeerlogdir [Undef]
-# @param fragicmp [Undef]
-# @param hidetos [Undef]
-# @param overridemtu [Undef]
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 # @author Jeanne Greulich <jeanne.greulich@onyxpoint.com>
@@ -81,35 +70,49 @@
 class libreswan (
   $service_name        = $::libreswan::params::service_name,
   $package_name        = $::libreswan::params::package_name,
-  $client_nets         = defined('$::client_nets') ? { true => getvar('::client_nets'), default => hiera('client_nets', ['127.0.0.1/32']) },
+  $ipsec_client_nets   = ['127.0.0.1/32'],
   $simp_firewall       = defined('$::simp_firewall') ? { true => getvar('::simp_firewall'), default => hiera('simp_firewall',false) },
   $use_fips            = defined('$::use_fips') ? { true => getvar('::use_fips'), default => hiera('use_fips',false) },
   $use_simp_pki        = defined('$::use_simp_pki') ? { true  => getvar('::use_simp_pki'), default => hiera('use_simp_pki',false) },
   $use_haveged         = defined('$::use_haveged') ? { true => getvar('::use_haveged'), default => hiera('use_haveged',true) },
   $nssdb_password      = passgen('nssdb_password'),
+  $certsource          = '/etc/pki/ipsec',
+  $pkiroot             = '/etc/pki',
   # Possible Values in ipsec.conf file
   $myid                = undef,
   $protostack          = 'netkey',
   $interfaces          = undef,
   $listen              = undef,
   $ikeport             = '500',
+  $nflog_all           = undef,
   $nat_ikeport         = '4500',
   $keep_alive          = undef,
-  $retransmits         = 'yes',
   $virtual_private     = ['10.0.0.0/8','192.168.0.0/16','172.16.0.0/12'],
   $myvendorid          = undef,
   $nhelpers            = undef,
+#seedbits
+#secctx-attr-type
   $plutofork           = undef,
   $crlcheckinterval    = undef,
   $strictcrlpolicy     = undef,
+  $ocsp_enable         = undef,
+  $ocsp_strict         = undef,
+  $ocsp_timeout        = undef,
+  $ocsp_uri            = undef,
+  $ocsp_trustname      = undef,
   $syslog              = undef,
   $klipsdebug          = 'none',
   $plutodebug          = 'none',
   $uniqueids           = undef,
   $plutorestartoncrash = undef,
-  $plutostderrlog      = undef,
-  $plutostderrlogtime  = undef,
-  $force_busy          = undef,
+  $logfile             = undef,
+  $logappend           = undef,
+  $logtime             = undef,
+  $ddos_mode           = undef,
+  $ddos_ike_treshold   = undef,  # incorrect spelling in libreswan 3.1.5 source code verified
+#max-halfopen-ike
+#shuntlifetime
+#xfrmlifetime
   $dumpdir             = '/var/run/pluto',
   $statsbin            = undef,
   $ipsecdir            = '/etc/ipsec.d',
@@ -119,65 +122,64 @@ class libreswan (
   $fragicmp            = undef,
   $hidetos             = undef,
   $overridemtu         = undef,
-  $ipsec_client_nets   = ['127.0.0.1/32'],
-  # Other Variables
-  $certsource          = '/etc/pki/ipsec',
-  $pkiroot             = '/etc/pki',
 
 ) inherits ::libreswan::params {
 
+  # TODO validate these in the same order they appear in the parameter
+  # list
   validate_string( $service_name )
   validate_string( $package_name )
-  validate_array( $client_nets )
   validate_array( $ipsec_client_nets )
+  validate_net_list( $ipsec_client_nets )
   validate_bool( $simp_firewall )
   validate_bool( $use_simp_pki )
   validate_bool( $use_fips )
   validate_bool( $use_haveged )
   # config setup section of ipsec.conf
-  if $strictcrlpolicy {
-    validate_re($strictcrlpolicy,
-      '(yes|no)$',
-      "${strictcrlpolicy} is not supported for strictcrlpolicy")
+  if $myid { validate_string($myid)}
+  if $strictcrlpolicy { libreswan_validate_yesno($strictcrlpolicy) }
+  if $hidetos { libreswan_validate_yesno($hidetos) }
+  if $plutofork { libreswan_validate_yesno($plutofork) }
+  if $uniqueids { libreswan_validate_yesno($uniqueids) }
+
+  #TODO validate list which can contain IP addresses prefixed by "!".  Right
+  # now validation is done in template that uses this variable
+  validate_array($virtual_private)
+  if $plutorestartoncrash { libreswan_validate_yesno($plutorestartoncrash) }
+  if $fragicmp { libreswan_validate_yesno($fragicmp) }
+  if $listen {
+    # This should be a single IPv4 or IPv6 address
+    # TODO reject CIDR addresses
+    validate_string($listen)
+    validate_net_list($listen)
   }
-  if $force_busy {
-    validate_re($force_busy,
-      '(yes|no)$',
-      "${force_busy} is not supported for force_busy")
-  }
-  if $hidetos {
-    validate_re($hidetos,
-    '(yes|no)$',"${hidetos} is not supported for hidetos")
-  }
-  if $plutofork {
-    validate_re($plutofork,
-      '(yes|no)$',
-      "${plutofork} is not supported for plutofork")
-  }
-  if $uniqueids {
-    validate_re($uniqueids, '(yes|no)$', "${uniqueids} is not supported for uniqueids")
-  }
-  if $retransmits {
-    validate_re($retransmits, '(yes|no)$', "${retransmits} is not supported for retransmits")
-  }
-  if $plutorestartoncrash {
-    validate_re($plutorestartoncrash, '(yes|no)$', "${plutorestartoncrash} is not supported for plutorestartoncrash")
-  }
-  if $fragicmp {
-    validate_re($fragicmp, '(yes|no)$', "${fragicmp} is not supported for fragicmp")
-  }
-  if $listen { validate_ipv4_address($listen) }
-  if $perpeerlog {
-    validate_re($perpeerlog, '(yes|no)$', "${perpeerlog} is not supported for perpeerlog")
-  }
+  if $perpeerlog { libreswan_validate_yesno($perpeerlog) }
+  validate_absolute_path($perpeerlogdir)
   if $nhelpers { validate_integer($nhelpers)}
   if $overridemtu { validate_integer($overridemtu)}
   if $keep_alive { validate_integer($keep_alive)}
   if $crlcheckinterval { validate_integer($crlcheckinterval)}
   if $myvendorid { validate_string($myvendorid)}
   if $statsbin { validate_string($statsbin)}
+  if $ocsp_enable { libreswan_validate_yesno($ocsp_enable) }
+  if $ocsp_strict { libreswan_validate_yesno($ocsp_strict) }
+  if $ocsp_timeout { validate_integer($ocsp_timeout) }
+  if $ocsp_uri {
+    validate_string($ocsp_uri) # must be single URI
+    validate_uri_list($ocsp_uri)
+  }
+  if $ocsp_trustname{ validate_string($ocsp_trustname) }
+
+  #TODO build validator for <facility>.<level>
   if $syslog { validate_string($syslog)}
-  if $plutostderrlog { validate_absolute_path ($plutostderrlog) }
+
+  validate_string($klipsdebug)
+  validate_string($plutodebug)
+  if $logfile { validate_absolute_path ($logfile) }
+  if $logappend { libreswan_validate_yesno($logappend) }
+  if $logtime { libreswan_validate_yesno($logtime) }
+  if $ddos_mode { validate_array_member($ddos_mode,['busy','unlimited','auto']) }
+  if $ddos_ike_treshold { validate_integer($ddos_ike_treshold) }
   validate_absolute_path($ipsecdir)
   validate_absolute_path($secretsfile)
   validate_absolute_path($dumpdir)
@@ -185,19 +187,13 @@ class libreswan (
   validate_absolute_path($pkiroot)
   validate_array_member($protostack,['netkey','klips','mast'])
   validate_integer($ikeport)
+  if $nflog_all { validate_integer($nflog_all) }
   validate_integer($nat_ikeport)
-  validate_re($retransmits,'(yes|no)$',"${retransmits} invalid for retransmits")
-  case $interfaces {
-    undef           : {}
-    '%none'         : {}
-    '%defaultroute' : {}
-    default         : {
-      validate_re($interfaces,
-        '((\w+=\w+)|(\%defaultroute))(\s+((\w+=\w+)|(\%defaultroute)))*',
-        "${interfaces} is not supported")
-    }
-  }
 
+  if $interfaces {
+    validate_array($interfaces)
+    validate_re_array($interfaces,['^%none$', '^%defaultroute$', '(\w+=\w+)'])
+  }
   # set the token for the NSS database.
   if $::libreswan::use_fips {
     $token = 'NSS FIPS 140-2 Certificate DB' }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-libreswan",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "author": "simp",
   "summary": "Manages IPSec VPN Tunnels",
   "license": "Apache-2.0",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -7,8 +7,8 @@ HOSTS:
       - libreswan
       - default
     platform:   el-7-x86_64
-    box:        puppetlabs/centos-7.0-64-nocm
-    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    box:        centos/7
+    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.2-64-nocm
     hypervisor: vagrant
   right:
     roles:
@@ -17,8 +17,8 @@ HOSTS:
       - agent
       - libreswan
     platform:   el-7-x86_64
-    box:        puppetlabs/centos-7.0-64-nocm
-    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    box:        centos/7
+    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.2-64-nocm
     hypervisor: vagrant
 CONFIG:
   log_level: verbose

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,4 +1,163 @@
 require 'spec_helper'
+top_comment = <<EOM
+# /etc/ipsec.conf - Libreswan IPsec configuration file
+#
+# This file is controlled by puppet.  Changes should be done through hiera.
+#
+# This file holds only the config setup section of ipsec.conf.
+# Connection information should be placed in seperate files in the directory
+# defined by libreswan::ipsecdir (default /etc/ipsec.d)
+# There is information on the possible values in the manual page, "man ipsec.conf"
+# or at https://libreswan.org
+#
+EOM
+
+logfile_comment = <<EOM
+  # Normally, pluto logs via syslog. If you want to log to a file,
+  # specify below or to disable logging, eg for embedded systems, use
+  # the file name /dev/null
+  # Note: SElinux policies might prevent pluto writing to a log file at
+  #       an unusual location.
+EOM
+
+plutodebug_comment = <<EOM
+  # Do not enable debug options to debug configuration issues!
+  # plutodebug "all", "none" or a combination from below:
+  # "raw crypt parsing emitting control controlmore kernel pfkey
+  #  natt x509 dpd dns oppo oppoinfo private".
+  # Note: "private" is not included with "all", as it can show confidential
+  #       information. It must be specifically specified
+  # examples:
+  # plutodebug="control parsing"
+  # plutodebug="all crypt"
+  # Again: only enable plutodebug when asked by a developer
+EOM
+
+dump_dir_comment = <<EOM
+  # Enable core dumps (might require system changes, like ulimit -C)
+  # This is required for abrtd to work properly
+  # Note: SElinux policies might prevent pluto writing the core at
+  #       unusual locations
+EOM
+
+protostack_comment = <<EOM
+  # which IPsec stack to use, "netkey" (the default), "klips" or "mast".
+  # For MacOSX use "bsd"
+EOM
+
+virtual_private_comment = <<EOM
+  #
+  # NAT-TRAVERSAL support
+  # exclude networks used on server side by adding %v4:!a.b.c.0/24
+  # It seems that T-Mobile in the US and Rogers/Fido in Canada are
+  # using 25/8 as "private" address space on their wireless networks.
+  # This range has never been announced via BGP (at least upto 2015)
+  #	virtual_private=%v4:10.0.0.0/8,%v4:192.168.0.0/16,%v4:172.16.0.0/12,%v4:25.0.0.0/8,%v4:100.64.0.0/10,%v6:fd00::/8,%v6:fe80::/10
+EOM
+
+include_comment = <<EOM
+#
+# You must add your IPsec connections as separate files in the ipsecdir
+#  (defined above (default /etc/ipsec.d/ )
+EOM
+
+ipsec_conf_content = {
+  :default =>
+    top_comment +
+    "config setup\n" +
+    "  ipsecdir = /etc/ipsec.d\n" +
+    "  ikeport = 500\n" +
+    "  nat-ikeport = 4500\n" +
+    "  klipsdebug = none\n" +
+    plutodebug_comment +
+    "  plutodebug = none\n" +
+    logfile_comment +
+    "  #logfile=/var/log/pluto.log\n" +
+    dump_dir_comment +
+    "  dumpdir = /var/run/pluto\n" +
+    "  secretsfile = /etc/ipsec.secrets\n" +
+    "  perpeerlogdir = /var/log/pluto/peer\n" +
+    protostack_comment +
+    "  protostack = netkey\n" +
+    virtual_private_comment +
+    "  virtual-private = %v4:10.0.0.0/8,%v4:192.168.0.0/16,%v4:172.16.0.0/12\n" +
+    include_comment +
+    "include /etc/ipsec.d/*.conf\n",
+
+  # This content is NOT a valid ipsec configuration, but simply a
+  # configuration that exercises parameter processing code.
+  :fully_specified =>
+    top_comment +
+    "config setup\n" +
+    "  ipsecdir = /etc/myipsec.d\n" +
+    "  myid = @myid\n" +
+    "  interfaces = \"ipsec0=eth0 ipsec1=ppp0\"\n" +
+    "  listen = 1.2.3.4\n" +
+    "  ikeport = 600\n" +
+    "  nflog-all = 10\n" +
+    "  nat-ikeport = 4600\n" +
+    "  keep-alive = 10\n" +
+    "  myvendorid = my-vendor-id\n" +
+    "  nhelpers = -1\n" +
+    "  plutofork = no\n" +
+    "  crlcheckinterval = 60\n" +
+    "  strictcrlpolicy = yes\n" +
+    "  ocsp-enable = yes\n" +
+    "  ocsp-strict = yes\n" +
+    "  ocsp-timeout = 4\n" +
+    "  ocsp-uri = https://myuri\n" +
+    "  ocsp-trustname = my-trustname\n" +
+    "  syslog = daemon.warning\n" +
+    "  klipsdebug = all\n" +
+    plutodebug_comment +
+    "  plutodebug = all\n" +
+    "  uniqueids = no\n" +
+    "  plutorestartoncrash = no\n" +
+    logfile_comment +
+    "  logfile = /var/log/ipsec.log\n" +
+    "  logappend = no\n" +
+    "  logtime = no\n" +
+    "  ddos-mode = busy\n" +
+    "  ddos-ike-treshold = 26000\n" +
+    dump_dir_comment +
+    "  dumpdir = /var/run/ipsec\n" +
+    "  statsbin = \"/some/external/reporter -p 266\"\n" +
+    "  secretsfile = /etc/myipsec.secrets\n" +
+    "  perpeerlog = yes\n" +
+    "  perpeerlogdir = /var/log/ipsec/peer\n" +
+    "  fragicmp = yes\n" +
+    "  hidetos = no\n" +
+    "  overridemtu = 1500\n" +
+    protostack_comment +
+    "  protostack = klips\n" +
+    virtual_private_comment +
+    "  virtual-private = %v4:1.2.3.0/24,%v6:fe80::/10,%v4:!5.6.0.0/16,%v6:!fd80::/10\n" +
+    include_comment +
+    "include /etc/myipsec.d/*.conf\n"
+}
+
+shared_examples_for "a libreswan ipsec config file generator" do
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to contain_file('/etc/ipsec.conf').with(
+    {
+      :owner   => 'root',
+      :mode    => '0400',
+      :notify  => 'Service[ipsec]',
+      :content => ipsec_conf_content[title]
+    })
+  }
+
+  it { is_expected.to contain_file(dumpdir).with(
+    {
+      :ensure => :directory,
+      :owner  => 'root',
+      :mode   => '0700',
+      :before => 'File[/etc/ipsec.conf]'
+    })
+  }
+
+end
+
 
 describe 'libreswan::config' do
   context 'supported operating systems' do
@@ -7,18 +166,137 @@ describe 'libreswan::config' do
         let(:facts) do
           facts
         end
-        let(:pre_condition) { 'class { "libreswan": service_name => "ipsec",}'}
 
         context 'with default parameters' do
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_class('libreswan::config') }
+          let(:pre_condition) { 'class { "libreswan": service_name => "ipsec",}'}
+          let(:title) { :default }
+          let(:dumpdir) { '/var/run/pluto' }
+
+          it_should_behave_like "a libreswan ipsec config file generator"
         end
-  
-        context "libreswan class without any parameters" do
-          it { is_expected.to create_file('/etc/ipsec.conf').with({
-            :owner   => 'root',
-            :mode    => '0400',
-            :notify  => 'Service[ipsec]',
+
+        context "with fully-specified parameters" do
+          let(:title) { :fully_specified }
+          let(:dumpdir) { '/var/run/ipsec' }
+          let(:pre_condition) { manifest = <<-EOM
+class { "libreswan":
+  service_name        => "ipsec",
+  myid                => '@myid',
+  protostack          => 'klips',
+  interfaces          => ['ipsec0=eth0','ipsec1=ppp0'],
+  listen              => '1.2.3.4',
+  ikeport             => '600',
+  nflog_all           => '10',
+  nat_ikeport         => '4600',
+  keep_alive          => '10',
+  virtual_private     => ['1.2.3.0/24', 'fe80::/10', '!5.6.0.0/16', '!fd80::/10'],
+  myvendorid          => 'my-vendor-id',
+  nhelpers            => '-1',
+  #seedbits
+  #secctx-attr-type
+  plutofork           => 'no',
+  crlcheckinterval    => '60',
+  strictcrlpolicy     => 'yes',
+  ocsp_enable         => 'yes',
+  ocsp_strict         => 'yes',
+  ocsp_timeout        => '4',
+  ocsp_uri            => 'https://myuri',
+  ocsp_trustname      => 'my-trustname',
+  syslog              => 'daemon.warning',
+  klipsdebug          => 'all',
+  plutodebug          => 'all',
+  uniqueids           => 'no',
+  plutorestartoncrash => 'no',
+  logfile             => '/var/log/ipsec.log',
+  logappend           => 'no',
+  logtime             => 'no',
+  ddos_mode           => 'busy',
+  ddos_ike_treshold   => '26000',
+  #max-halfopen-ike
+  #shuntlifetime
+  #xfrmlifetime
+  dumpdir             => '/var/run/ipsec',
+  statsbin            => '/some/external/reporter -p 266',
+  ipsecdir            => '/etc/myipsec.d',
+  secretsfile         => '/etc/myipsec.secrets',
+  perpeerlog          => 'yes',
+  perpeerlogdir       => '/var/log/ipsec/peer',
+  fragicmp            => 'yes',
+  hidetos             => 'no',
+  overridemtu         => '1500',
+}
+EOM
+          }
+
+          it_should_behave_like "a libreswan ipsec config file generator"
+          it { is_expected.to contain_file('/var/log/ipsec.log').with(
+            {
+              :owner  => 'root',
+              :mode   => '0600',
+              :before => 'File[/etc/ipsec.conf]'
+            })
+          }
+        end
+
+        context "with mixed/upper case yes/no parameters" do
+          let(:title) { :fully_specified }
+          let(:dumpdir) { '/var/run/ipsec' }
+          let(:pre_condition) { manifest = <<-EOM
+class { "libreswan":
+  service_name        => "ipsec",
+  myid                => '@myid',
+  protostack          => 'klips',
+  interfaces          => ['ipsec0=eth0','ipsec1=ppp0'],
+  listen              => '1.2.3.4',
+  ikeport             => '600',
+  nflog_all           => '10',
+  nat_ikeport         => '4600',
+  keep_alive          => '10',
+  virtual_private     => ['1.2.3.0/24', 'fe80::/10', '!5.6.0.0/16', '!fd80::/10'],
+  myvendorid          => 'my-vendor-id',
+  nhelpers            => '-1',
+  #seedbits
+  #secctx-attr-type
+  plutofork           => 'NO',
+  crlcheckinterval    => '60',
+  strictcrlpolicy     => 'YES',
+  ocsp_enable         => 'Yes',
+  ocsp_strict         => 'Yes',
+  ocsp_timeout        => '4',
+  ocsp_uri            => 'https://myuri',
+  ocsp_trustname      => 'my-trustname',
+  syslog              => 'daemon.warning',
+  klipsdebug          => 'all',
+  plutodebug          => 'all',
+  uniqueids           => 'No',
+  plutorestartoncrash => 'No',
+  logfile             => '/var/log/ipsec.log',
+  logappend           => 'No',
+  logtime             => 'No',
+  ddos_mode           => 'busy',
+  ddos_ike_treshold   => '26000',
+  #max-halfopen-ike
+  #shuntlifetime
+  #xfrmlifetime
+  dumpdir             => '/var/run/ipsec',
+  statsbin            => '/some/external/reporter -p 266',
+  ipsecdir            => '/etc/myipsec.d',
+  secretsfile         => '/etc/myipsec.secrets',
+  perpeerlog          => 'Yes',
+  perpeerlogdir       => '/var/log/ipsec/peer',
+  fragicmp            => 'Yes',
+  hidetos             => 'No',
+  overridemtu         => '1500',
+}
+EOM
+          }
+
+          it_should_behave_like "a libreswan ipsec config file generator"
+          it { is_expected.to contain_file('/var/log/ipsec.log').with(
+            {
+              :owner  => 'root',
+              :mode   => '0600',
+              :before => 'File[/etc/ipsec.conf]'
             })
           }
         end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,7 +22,7 @@ describe 'libreswan' do
 
         context "libreswan class with firewall enabled" do
           let(:params) {{
-            :client_nets     => ['all'],
+            :ipsec_client_nets     => ['192.168.0.0/16'],
             :ikeport => '50',
             :nat_ikeport => '4500',
             :simp_firewall => true,
@@ -46,12 +46,229 @@ describe 'libreswan' do
           it { is_expected.to_not contain_class('haveged') }
         end
 
-        context 'with invalid input' do
-          let(:params) {{:use_haveged => 'invalid_input'}}
-          it 'with use_haveged as a string' do
-            expect {
-              is_expected.to compile
-            }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/invalid_input" is not a boolean/)
+        #TODO flesh out full list of validation successes and failures,
+
+        describe 'accept valid parameter options' do
+          describe 'ddos-mode enum' do
+            [ 'busy','unlimited', 'auto'].each do |valid_enum|
+              context "ddos-mod #{valid_enum}" do
+                let(:params) {{:ddos_mode => valid_enum}}
+                it { is_expected.to compile}
+              end
+            end
+          end
+
+          describe 'protostack enum' do
+            [ 'netkey','klips', 'mast'].each do |valid_enum|
+              context "protostack #{valid_enum}" do
+                let(:params) {{:protostack => valid_enum}}
+                it { is_expected.to compile}
+              end
+            end
+          end
+
+          describe 'interfaces enum' do
+            [ ['%none'], ['%defaultroute'], ['ipsec0=eth1', 'ipsec1=ppp0'] ].each do |valid_enum|
+              context "protostack #{valid_enum}" do
+                let(:params) {{:interfaces => valid_enum}}
+                it { is_expected.to compile}
+              end
+            end
+          end
+        end
+
+        describe 'with invalid yes/no parameters' do
+          [ :strictcrlpolicy,
+            :hidetos,
+            :plutofork,
+            :uniqueids,
+            :plutorestartoncrash,
+            :fragicmp,
+            :perpeerlog,
+            :ocsp_enable,
+            :ocsp_strict,
+            :logappend,
+            :logtime
+          ].each do |yesno_param|
+            context "invalid #{yesno_param}" do
+              let(:params) {{yesno_param => 'false'}}
+              it 'fails to compile' do
+                expect {
+                  is_expected.to compile
+                }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'false' is not 'yes' or 'no'/)
+              end
+            end
+          end
+        end
+
+        describe 'with invalid integer parameters' do
+          [ :nhelpers,
+            :overridemtu,
+            :keep_alive,
+            :crlcheckinterval,
+            :ocsp_timeout,
+            :ddos_ike_treshold,
+            :ikeport,
+            :nflog_all,
+            :nat_ikeport
+          ].each do |int_param|
+            context "invalid #{int_param}" do
+              let(:params) {{int_param => 'not-a-number'}}
+              it 'fails to compile' do
+                expect {
+                  is_expected.to compile
+                }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'\["not-a-number"\]' is not an integer/)
+              end
+            end
+          end
+        end
+
+        describe 'with invalid bool parameters' do
+          [ :simp_firewall,
+            :use_simp_pki,
+            :use_fips,
+            :use_haveged
+          ].each do |bool_param|
+            context "invalid #{bool_param}" do
+              let(:params) {{bool_param => 'FALSE'}}
+              it 'fails to compile' do
+                expect {
+                  is_expected.to compile
+                }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/FALSE" is not a boolean/)
+              end
+            end
+          end
+        end
+
+        describe 'with invalid absolute path parameters' do
+          [ :perpeerlogdir,
+            :logfile,
+            :ipsecdir,
+            :secretsfile,
+            :dumpdir,
+            :certsource,
+            :pkiroot
+          ].each do |abs_path_param|
+            context "invalid #{abs_path_param}" do
+              let(:params) {{abs_path_param => './myfile'}}
+              it 'fails to compile' do
+                expect {
+                  is_expected.to compile
+                }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/".\/myfile" is not an absolute path/)
+              end
+            end
+          end
+        end
+
+        describe 'with invalid string parameters' do
+          [ :service_name,
+            :package_name,
+            :myid,
+            :listen,
+            :myvendorid,
+            :statsbin,
+            :ocsp_uri,
+            :ocsp_trustname,
+            :syslog,
+            :klipsdebug,
+            :plutodebug
+          ].each do |string_param|
+            context "invalid #{string_param}" do
+              let(:params) {{string_param => ['string-in-an-array']}}
+              it 'fails to compile' do
+                expect {
+                  is_expected.to compile
+                }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/\["string-in-an-array"\] is not a string/)
+              end
+            end
+          end
+        end
+
+        describe 'with invalid parameters' do
+          context 'invalid ipsec_client_nets' do
+#TODO renable this example once simplib's validate_net_list is fixed!
+#            let(:params) {{:ipsec_client_nets => ['1.2.3.4/33']}}
+            let(:params) {{:ipsec_client_nets => ['1.2..4/32']}}
+            it 'fails to compile' do
+              expect {
+                is_expected.to compile
+              }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'1.2..4\/32' is not a valid network/)
+            end
+          end
+
+          context 'invalid virtual_private' do
+            let(:params) {{:virtual_private => '1.2.3.0/24'}}
+            it 'fails to compile' do
+              expect {
+                is_expected.to compile
+              }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/"1.2.3.0\/24" is not an Array/)
+            end
+          end
+
+          context 'invalid ocsp_uri' do
+            let(:params) {{:ocsp_uri => ':myuri'}}
+            it 'fails to compile' do
+              expect {
+                is_expected.to compile
+              }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/':myuri' is not a valid URI/)
+            end
+          end
+
+          context 'invalid ddos_mode' do
+            let(:params) {{:ddos_mode => 'none'}}
+            it 'fails to compile' do
+              expect {
+                is_expected.to compile
+              }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'busy,unlimited,auto' does not contain 'none'/)
+            end
+          end
+
+          context 'invalid protostack' do
+            let(:params) {{:protostack => 'none'}}
+            it 'fails to compile' do
+              expect {
+                is_expected.to compile
+              }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'netkey,klips,mast' does not contain 'none'/)
+            end
+          end
+
+          context 'malformed listen' do
+            let(:params) {{:listen => '1..2.3'}}
+            it 'fails to compile' do
+              expect {
+                is_expected.to compile
+              }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'1..2.3' is not a valid network/)
+            end
+          end
+
+#TODO enable once code validates this
+=begin
+          context 'invalid listen' do
+            let(:params) {{:listen => '1.2.3.0/24'}}
+            it 'fails to compile' do
+              expect {
+                is_expected.to compile
+              }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'1..2.3' is not a valid network/)
+            end
+          end
+=end
+
+          context 'invalid interfaces' do
+            let(:params) {{:interfaces => ['eth1=']}}
+            it 'fails to compile' do
+              expect {
+                is_expected.to compile
+              }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/"eth1=" does not match/)
+            end
+          end
+
+          context "with invalid virtual_private " do
+            let(:params) {{:virtual_private     => ['267.2.3.0/24']}}
+            it 'fails to compile' do
+              expect {
+                is_expected.to compile
+              }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/267.2.3.0\/24 in virtual_private is not an IPv4\/IPv6 address/)
+            end
           end
         end
       end

--- a/spec/defines/add_connection_spec.rb
+++ b/spec/defines/add_connection_spec.rb
@@ -1,4 +1,127 @@
 require 'spec_helper'
+
+connection_conf_content = {
+  :default =>
+    "conn %default\n" +
+    "# Left Side Settings\n" +
+    "\n" +
+    "# Right Side Settings\n" +
+    "\n" +
+    "# Universal Settings\n" +
+    "  ike = aes-sha2;dh24\n" +
+    "  phase2alg = aes-sha2;dh24\n" +
+    "  fragmentation = force\n" +
+    "  xauthby = pam\n" +
+    "  xauthfail = hard\n" +
+    "  keyingtries = 10\n",
+
+  :outgoing =>
+    "conn outgoing\n" +
+    "# Left Side Settings\n" +
+    "  left = 10.0.0.1\n" +
+    "  leftcert = %cert\n" +
+    "  leftsendcert = always\n" +
+    "\n" +
+    "# Right Side Settings\n" +
+    "\n" +
+    "# Universal Settings\n" +
+    "  ike = aes-sha2;dh24\n" +
+    "  phase2alg = aes-sha2;dh24\n" +
+    "  keyingtries = 10\n",
+
+  # This content is NOT a usable connection file, but exercises default logic
+  :minimally_specified_conn =>
+    "conn minimally_specified_conn\n" +
+    "# Left Side Settings\n" +
+    "\n" +
+    "# Right Side Settings\n" +
+    "\n" +
+    "# Universal Settings\n" +
+    "  ike = aes-sha2;dh24\n" +
+    "  phase2alg = aes-sha2;dh24\n" +
+    "  keyingtries = 10\n",
+
+  # This content is NOT a usable connection file, but exercises non-default logic
+  :maximally_specified_conn =>
+    "conn maximally_specified_conn\n" +
+    "# Left Side Settings\n" +
+    "  left = 10.11.11.1\n" +
+    "  leftid = %myid\n" +
+    "  leftupdown = /some/left/updown/script\n" +
+    "  leftcert = my-left-cert-nickname\n" +
+    "  leftca = myleftca\n" +
+    "  leftprotoport = 17/1057\n" +
+    "  leftsourceip = 10.0.1.1\n" +
+    "  leftrsasigkey = %cert\n" +
+    "  leftrsasigkey2 = %dnsondemand\n" +
+    "  leftsendcert = sendifasked\n" +
+    "  leftsubnet = 10.0.1.0/24\n" +
+    "  leftsubnets = {10.0.3.0/24 10.0.5.0/24}\n" +
+    "  leftnexthop = 172.16.55.66\n" +
+    "  leftaddresspool = 10.0.1.100-10.0.1.200\n" +
+    "  leftxauthserver = yes\n" +
+    "  leftxauthusername = leftuser\n" +
+    "  leftxauthclient = yes\n" +
+    "  leftmodecfgserver = yes\n" +
+    "  leftmodecfgclient = yes\n" +
+    "\n" +
+    "# Right Side Settings\n" +
+    "  right = 192.168.22.1\n" +
+    "  rightid = %fromcert\n" +
+    "  rightupdown = /some/right/updown/script\n" +
+    "  rightcert = my-right-cert-nickname\n" +
+    "  rightca = myrightca\n" +
+    "  rightprotoport = tcp/%any\n" +
+    "  rightsourceip = 10.0.2.1\n" +
+    "  rightrsasigkey = %dnsonload\n" +
+    "  rightrsasigkey2 = %none\n" +
+    "  rightsendcert = yes\n" +
+    "  rightsubnet = 10.0.2.0/24\n" +
+    "  rightsubnets = {10.0.4.0/24 10.0.6.0/24}\n" +
+    "  rightnexthop = 172.16.88.99\n" +
+    "  rightaddresspool = 192.168.1.100-192.168.1.200\n" +
+    "  rightxauthserver = yes\n" +
+    "  rightxauthusername = rightuser\n" +
+    "  rightxauthclient = yes\n" +
+    "  rightmodecfgserver = yes\n" +
+    "  rightmodecfgclient = yes\n" +
+    "\n" +
+    "# Universal Settings\n" +
+    "  connaddrfamily = ipv4\n" +
+    "  authby = secret|rsasig\n" +
+    "  type = tunnel\n" +
+    "  auto = ondemand\n" +
+    "  ike = aes_gcm256-sha2;dh23\n" +
+    "  ikev2 = insist\n" +
+    "  phase2 = ah\n" +
+    "  phase2alg = 3des-md5;modp1024\n" +
+    "  sareftrack = conntrack\n" +
+    "  narrowing = yes\n" +
+    "  ikepad = no\n" +
+    "  fragmentation = no\n" +
+    "  sha2-truncbug = no\n" +
+    "  nat-ikev1-method = drafts\n" +
+    "  xauthby = alwaysok\n" +
+    "  xauthfail = soft\n" +
+    "  modecfgpull = yes\n" +
+    "  modecfgdns1 = 8.8.8.8\n" +
+    "  modecfgdns2 = 8.8.4.4\n" +
+    "  modecfgdomain = test.domain\n" +
+    "  modecfgbanner = test banner\n" +
+    "  keyingtries = 5\n"
+}
+
+shared_examples_for "a libreswan connection config file generator" do
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to contain_file(conn_name).with(
+    {
+      :notify  => 'Service[ipsec]',
+      :path    => "#{params[:dir]}/#{title}.conf",
+      :content => connection_conf_content[title]
+    })
+  }
+end
+
 describe 'libreswan::add_connection', :type => :define do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
@@ -8,24 +131,406 @@ describe 'libreswan::add_connection', :type => :define do
         end
         let(:common_params) { { :dir => '/etc/ipsec.d', } }
 
-        describe "create default" do
-          let(:title  ){ 'default' }
-          let(:params) { common_params.merge({ :left => '10.0.0.1', :leftcert => '%cert', :leftsendcert => 'always' }) }
-          it { is_expected.to contain_file('%default').with({
-            :notify  => 'Service[ipsec]',
-            :path    => "#{params[:dir]}/#{title}.conf",
-            })
-          }
+        describe 'create %default connection config' do
+          let(:conn_name  ){ '%default' }
+          let(:title  ){ :default }
+          let(:params) { common_params.merge({ :fragmentation => 'force', :xauthby => 'pam', :xauthfail => 'hard' }) }
+
+          it_should_behave_like "a libreswan connection config file generator"
         end
 
-        describe "create outgoing" do
+        describe 'create other connection config' do
+          let(:conn_name){ 'outgoing' }
+          let(:title){ :outgoing }
           let(:params) { common_params.merge({ :left => '10.0.0.1', :leftcert => '%cert', :leftsendcert => 'always' }) }
-          let(:title){ 'outgoing' }
-          it { is_expected.to contain_file("#{title}").with({
-            :notify  => 'Service[ipsec]',
-            :path    => "#{params[:dir]}/#{title}.conf",
+
+          it_should_behave_like "a libreswan connection config file generator"
+        end
+
+        describe 'create file with only default params' do
+          let(:conn_name){ 'minimally_specified_conn' }
+          let(:title){ :minimally_specified_conn }
+          let(:params) { common_params}
+
+          it_should_behave_like "a libreswan connection config file generator"
+        end
+
+        describe 'create file with fully-specified params' do
+          let(:conn_name){ 'maximally_specified_conn' }
+          let(:title){ :maximally_specified_conn }
+          let(:params) { common_params.merge(
+            { :keyingtries        => 5,
+              :ike                => 'aes_gcm256-sha2;dh23',
+              :phase2alg          => '3des-md5;modp1024',
+              :left               => '10.11.11.1',
+              :right              => '192.168.22.1',
+              :connaddrfamily     => 'ipv4',
+              :leftaddresspool    => ['10.0.1.100', '10.0.1.200'],
+              :leftsubnet         => '10.0.1.0/24',
+              :leftsubnets        => ['10.0.3.0/24', '10.0.5.0/24'],
+              :leftprotoport      => '17/1057',
+              :leftsourceip       => '10.0.1.1',
+              :leftupdown         => '/some/left/updown/script',
+              :leftcert           => 'my-left-cert-nickname',
+              :leftrsasigkey      => '%cert',
+              :leftrsasigkey2     => '%dnsondemand',
+              :leftsendcert       => 'sendifasked',
+              :leftnexthop        => '172.16.55.66',
+              :leftid             => '%myid',
+              :leftca             => 'myleftca',
+              :rightid            => '%fromcert',
+              :rightrsasigkey     => '%dnsonload',
+              :rightrsasigkey2    => '%none',
+              :rightca            => 'myrightca',
+              :rightaddresspool   => ['192.168.1.100', '192.168.1.200'],
+              :rightsubnet        => '10.0.2.0/24',
+              :rightsubnets       => ['10.0.4.0/24', '10.0.6.0/24'],
+              :rightprotoport     => 'tcp/%any',
+              :rightsourceip      => '10.0.2.1',
+              :rightupdown        => '/some/right/updown/script',
+              :rightcert          => 'my-right-cert-nickname',
+              :rightsendcert      => 'yes',
+              :rightnexthop       => '172.16.88.99',
+              :auto               => 'ondemand',
+              :authby             => 'secret|rsasig',
+              :type               => 'tunnel',
+              :ikev2              => 'insist',
+              :phase2             => 'ah',
+	      :ikepad             => 'no',
+              :fragmentation      => 'no',
+              :sha2_truncbug      => 'no',
+              :narrowing          => 'yes',
+              :sareftrack         => 'conntrack',
+              :leftxauthserver    => 'yes',
+              :rightxauthserver   => 'yes',
+              :leftxauthusername  => 'leftuser',
+              :rightxauthusername => 'rightuser',
+              :leftxauthclient    => 'yes',
+              :rightxauthclient   => 'yes',
+              :leftmodecfgserver  => 'yes',
+              :rightmodecfgserver => 'yes',
+              :leftmodecfgclient  => 'yes',
+              :rightmodecfgclient => 'yes',
+              :xauthby            => 'alwaysok',
+              :xauthfail          => 'soft',
+              :modecfgpull        => 'yes',
+              :modecfgdns1        => '8.8.8.8',
+              :modecfgdns2        => '8.8.4.4',
+              :modecfgdomain      => 'test.domain',
+              :modecfgbanner      => 'test banner',
+              :nat_ikev1_method   => 'drafts',
             })
           }
+
+          it_should_behave_like "a libreswan connection config file generator"
+        end
+
+        # TODO flesh out more success and failure validation cases,
+        # especially regex validations and IPv6 cases
+        #
+        describe 'accept valid parameter options' do
+          describe 'magic IP enum' do
+            [ :left, :right ].each do |ip_enum|
+              [ '%any','%opportunistic', '%group', '%opportunisticgroup'].each do |valid_enum|
+                context "#{ip_enum} of #{valid_enum}" do
+                  let(:title){ "#{ip_enum}_#{valid_enum}" }
+                  let(:params) {{ip_enum => valid_enum}}
+                  it { is_expected.to compile}
+                end
+              end
+            end
+          end
+
+          describe 'magic subnet enum' do
+	    [ :leftsubnet, :rightsubnet ].each do |subnet_enum|
+	      [ 'vhost:%priv,%no','vnet:%priv' ].each do |valid_enum|
+	        context "#{subnet_enum} of #{valid_enum}" do
+	          let(:title){ "#{subnet_enum}_#{valid_enum}" }
+	          let(:params) {{subnet_enum => valid_enum}}
+	          it {
+                    pending 'Currently, REGEX matching for validate_net_list is broken'
+                    is_expected.to compile
+                  }
+                end
+	      end
+	    end
+          end
+
+          describe 'magic nexthop enum' do
+	    [ :leftnexthop, :rightnexthop ].each do |nexthop_enum|
+	      [ '%direct','%defaultroute' ].each do |valid_enum|
+	        context "#{nexthop_enum} of #{valid_enum}" do
+	          let(:title){ "#{nexthop_enum}_#{valid_enum}" }
+	          let(:params) {{nexthop_enum => valid_enum}}
+	          it { is_expected.to compile }
+                end
+	      end
+	    end
+          end
+
+          describe 'sendcert enum' do
+	    [ :leftsendcert, :rightsendcert ].each do |sendcert_enum|
+	      [ 'yes', 'no', 'never', 'always', 'sendifasked' ].each do |valid_enum|
+	        context "#{sendcert_enum} of #{valid_enum}" do
+	          let(:title){ "#{sendcert_enum}_#{valid_enum}" }
+	          let(:params) {{sendcert_enum => valid_enum}}
+	          it { is_expected.to compile }
+                end
+	      end
+	    end
+          end
+
+          describe 'authby enum' do
+	    [ 'rsasig','secret', 'secret|rsasig', 'never', 'null' ].each do |valid_enum|
+	      context "authby of #{valid_enum}" do
+	        let(:title){ "authby_#{valid_enum}" }
+	        let(:params) {{:authby => valid_enum}}
+	        it { is_expected.to compile }
+              end
+            end
+          end
+
+          describe 'auto enum' do
+	    [ 'add','start','ondemand','ignore' ].each do |valid_enum|
+	      context "auto of #{valid_enum}" do
+	        let(:title){ "auto_#{valid_enum}" }
+	        let(:params) {{:auto => valid_enum}}
+	        it { is_expected.to compile }
+              end
+            end
+          end
+
+          describe 'connaddrfamily enum' do
+	    [ 'ipv4', 'ipv6' ].each do |valid_enum|
+	      context "connaddrfamily of #{valid_enum}" do
+	        let(:title){ "connaddrfamily_#{valid_enum}" }
+	        let(:params) {{:connaddrfamily => valid_enum}}
+	        it { is_expected.to compile }
+              end
+            end
+          end
+
+          describe 'type enum' do
+	    [ 'tunnel','transport','passthough','reject','drop' ].each do |valid_enum|
+	      context "type of #{valid_enum}" do
+	        let(:title){ "type_#{valid_enum}" }
+	        let(:params) {{:type => valid_enum}}
+	        it { is_expected.to compile }
+              end
+            end
+          end
+#TODO ikev2
+#TODO phase2
+#TODO nat_ikev1_method
+#TODO fragmentation
+#TODO sareftrack
+#TODO xauthby
+#TODO xauthfail
+#TODO leftrsasigkey, leftrsasigkey2, rightrsasigkey, rightrsasigkey2
+        end
+
+        describe 'reject invalid parameters' do
+          describe 'yes/no parameter' do
+            [ :ikepad,
+              :narrowing,
+              :sha2_truncbug,
+              :leftxauthserver,
+              :rightxauthserver,
+              :leftxauthclient,
+              :rightxauthclient,
+              :leftmodecfgserver,
+              :rightmodecfgserver,
+              :leftmodecfgclient,
+              :rightmodecfgclient,
+              :modecfgpull
+            ].each do |yesno_param|
+              context "invalid #{yesno_param}" do
+                let(:title){ "invalid_#{yesno_param}" }
+                let(:params) {{yesno_param => 'true'}}
+                it 'fails to compile' do
+                  expect {
+                    is_expected.to compile
+                  }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'true' is not 'yes' or 'no'/)
+                end
+              end
+            end
+          end
+
+          describe 'string parameter' do
+            [ :left,
+              :right,
+              :leftsourceip,
+              :rightsourceip,
+              :rightsubnet,
+              :leftsubnet,
+              :leftnexthop,
+              :rightnexthop,
+              :leftupdown,
+              :rightupdown,
+              :leftcert,
+              :rightcert,
+              :leftid,
+              :rightid,
+              :leftca,
+              :rightca,
+              :leftxauthusername,
+              :rightxauthusername,
+              :modecfgdns1,
+              :modecfgdns2,
+              :modecfgdomain,
+              :modecfgbanner,
+              :phase2alg,
+              :ike
+            ].each do |string_param|
+              context "invalid string #{string_param}" do
+                let(:title){ "invalid_string_#{string_param}" }
+                let(:params) {{string_param => ['string-in-an-array']}}
+                it 'fails to compile' do
+                  expect {
+                    is_expected.to compile
+                  }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/\["string-in-an-array"\] is not a string/)
+                end
+              end
+            end
+          end
+
+          describe 'single IP address' do
+            [ :left,
+              :right,
+              :leftsourceip,
+              :rightsourceip,
+              :leftnexthop,
+              :rightnexthop,
+              :modecfgdns1,
+              :modecfgdns2
+            ].each do |ipaddr_param|
+              context "invalid #{ipaddr_param}" do
+                let(:title){ "invalid_#{ipaddr_param}" }
+                let(:params) {{ipaddr_param => '1.2..4.'}}
+                it 'fails to compile' do
+                  expect {
+                    is_expected.to compile
+                  }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'1.2..4.' is not a valid network/)
+                end
+              end
+
+              context 'CIDR address' do
+                it 'rejects CIDR address' do
+                  pending 'Currently, CIDR addresses are not rejected'
+                  expect {
+                    is_expected.to compile
+                  }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'1.2..4.' is not a valid network/)
+                end
+              end
+            end
+          end
+
+          describe 'pair of IP addresses (not CIDR)' do
+            [ :leftaddresspool, :rightaddresspool ].each do |addr_pool_param|
+              context "#{addr_pool_param} array not length 2" do
+                let(:title){ "invalid_length_#{addr_pool_param}" }
+                let(:params) {{addr_pool_param => ['1.2.3.4']}}
+                it 'fails to compile' do
+                  pending "Currently, length of array is not validated."
+                  expect {
+                    is_expected.to compile
+                  }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/#{addr_pool_param} must have 2 values/)
+                end
+              end
+
+              context "#{addr_pool_param} contains CIDR addresses"  do
+                let(:title){ "invalid_cidr_#{addr_pool_param}" }
+                let(:params) {{addr_pool_param => ['1.2.4.0/24', '5.7.8.0/24'] }}
+                it 'fails to compile' do
+                  pending "Currently, CIDR addresses are not rejected"
+                  expect {
+                    is_expected.to compile
+                  }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'1..30.0' is not a valid network/)
+                end
+              end
+            end
+          end
+
+          describe 'single CIDR address' do
+            [ :leftsubnet,
+              :rightsubnet,
+              :leftsubnets,
+              :rightsubnets
+            ].each do |cidr_param|
+              context "invalid CIDR address #{cidr_param}" do
+                let(:title){ "invalid_cidr_#{cidr_param}" }
+                let(:params) {{cidr_param => '1.2..30.0/24'}}
+                it 'fails to compile' do
+                  expect {
+                    is_expected.to compile
+                  }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'1.2..30.0\/24' is not a valid network/)
+                end
+              end
+
+              context "not CIDR address #{cidr_param}" do
+                it 'fails to compile' do
+                  pending "Currently, non-CIDR addresses are not rejected"
+                  expect {
+                    is_expected.to compile
+                  }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'1.2..30.0\/24' is not a valid network/)
+                end
+              end
+            end
+          end
+
+          describe 'array of CIDR addresses' do
+            [ :leftsubnets, :rightsubnets ].each do |cidr_param|
+              context "invalid CIDR address #{cidr_param}" do
+                let(:title){ "invalid_cidr_array_#{cidr_param}" }
+                let(:params) {{cidr_param => ['1.2..30.0/24', '1.2.3.4']}}
+                it 'fails to compile' do
+                  expect {
+                    is_expected.to compile
+                  }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'1.2..30.0\/24' is not a valid network/)
+                end
+              end
+              context "not CIDR address #{cidr_param}" do
+                it 'fails to compile' do
+                  pending "Currently, non-CIDR addresses are not rejected"
+                  expect {
+                    is_expected.to compile
+                  }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/'1.2..30.0\/24' is not a valid network/)
+                end
+              end
+            end
+          end
+
+          describe 'enumerated list' do
+            [ :authby,
+              :auto,
+              :leftsendcert,
+              :rightsendcert,
+              :type,
+              :ikev2,
+              :phase2,
+              :nat_ikev1_method,
+              :fragmentation,
+              :sareftrack,
+              :xauthby,
+              :xauthfail
+            ].each do |enum_param|
+              context "invalid enumeration #{enum_param}" do
+                let(:title){ "invalid_enum_#{enum_param}" }
+                let(:params) {{enum_param => 'not-in-enumerated-list'}}
+                it 'fails to compile' do
+                  expect {
+                    is_expected.to compile
+                  }.to raise_error(RSpec::Expectations::ExpectationNotMetError,/does not contain 'not-in-enumerated-list'/)
+                end
+              end
+            end
+          end
+
+          context 'when connaddrfamily is invalid' do
+            let(:title){ :invalid_connaddrfamily }
+            let(:params) { common_params.merge({ :connaddrfamily => 'IPV4' }) }
+            it { is_expected.to_not compile.with_all_deps }
+          end
         end
       end
     end

--- a/spec/functions/libreswan_validate_yesno_spec.rb
+++ b/spec/functions/libreswan_validate_yesno_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'libreswan_validate_yesno' do
+  ['yes', 'Yes', 'yEs', 'yeS', 'YEs', 'yES', 'YeS', 'YES',
+      'no', 'No', 'nO', 'NO'].each do |test_string|
+    it "validates a #{test_string} argument as a yes/no variant" do
+      expect { subject.call([test_string]) }.to_not raise_error
+    end
+  end
+
+  it 'accepts yes/no strings with whitespace' do
+    [' yes', 'no ', "\tyes\t"].each do |test_string|
+      expect { subject.call([test_string]) }.to_not raise_error
+    end
+  end
+
+  it 'rejects no arguments' do
+    expect { subject.call([]) }.to raise_error(Puppet::ParseError, /libreswan_validate_yesno\(\): Must pass a string/)
+  end
+
+  it 'rejects too many arguments' do
+      expect { subject.call([['yes', 'yes']]) }.to raise_error(Puppet::ParseError, /libreswan_validate_yesno\(\): arg must be a String/)
+  end
+
+  it 'rejects non-yes/no strings' do
+    ['true', 'false', ""].each do |test_string|
+      expect { subject.call([test_string]) }.to raise_error(Puppet::ParseError, /libreswan_validate_yesno\(\): '#{test_string}' is not 'yes' or 'no'/)
+    end
+  end
+end

--- a/templates/etc/ipsec.conf.erb
+++ b/templates/etc/ipsec.conf.erb
@@ -6,22 +6,26 @@
 # Connection information should be placed in seperate files in the directory
 # defined by libreswan::ipsecdir (default /etc/ipsec.d)
 # There is information on the possible values in the manual page, "man ipsec.conf"
-#  or at https://libreswan.org
+# or at https://libreswan.org
 #
-
+<%-# TODO order settings to match Libreswan documentation -%>
 config setup
-  ipsecdir = <%= scope['::libreswan::ipsecdir'] %>
+  ipsecdir = <%= @ipsecdir %>
 <% if @myid  then -%>
-  myid = <%= scope['::libreswan::myid'] %>
+  myid = <%= @myid %>
 <% end -%>
+<%-# Quotes are required because this may be an array of whitespace-separated interfaces -%>
 <% if @interfaces  then -%>
-  interfaces = <%= scope['::libreswan::interfaces'] %>
+  interfaces = "<%= @interfaces.join(' ') %>"
 <% end -%>
 <% if @listen  then -%>
-  listen = <%= scope['::libreswan::listen'] %>
+  listen = <%= @listen %>
 <% end -%>
-  ikeport = <%= scope['::libreswan::ikeport'] %>
-  nat-ikeport = <%= scope['::libreswan::nat_ikeport'] %>
+  ikeport = <%= @ikeport %>
+<% if @nflog_all  then -%>
+  nflog-all = <%= @nflog_all %>
+<% end -%>
+  nat-ikeport = <%= @nat_ikeport %>
 <% if @keep_alive  then -%>
   keep-alive = <%= @keep_alive %>
 <% end -%>
@@ -32,90 +36,132 @@ config setup
   nhelpers = <%= @nhelpers %>
 <% end -%>
 <% if @plutofork  then -%>
-  plutofork = <%= @plutofork %>
+  plutofork = <%= @plutofork.downcase.strip %>
 <% end -%>
 <% if @crlcheckinterval  then -%>
   crlcheckinterval = <%= @crlcheckinterval %>
 <% end -%>
 <% if @strictcrlpolicy  then -%>
-  strictcrlpolicy = <%= @strictcrlpolicy %>
+  strictcrlpolicy = <%= @strictcrlpolicy.downcase.strip %>
+<% end -%>
+<% if @ocsp_enable  then -%>
+  ocsp-enable = <%= @ocsp_enable.downcase.strip %>
+<% end -%>
+<% if @ocsp_strict  then -%>
+  ocsp-strict = <%= @ocsp_strict.downcase.strip %>
+<% end -%>
+<% if @ocsp_timeout  then -%>
+  ocsp-timeout = <%= @ocsp_timeout %>
+<% end -%>
+<% if @ocsp_uri  then -%>
+  ocsp-uri = <%= @ocsp_uri %>
+<% end -%>
+<% if @ocsp_trustname  then -%>
+  ocsp-trustname = <%= @ocsp_trustname %>
 <% end -%>
 <% if @syslog  then -%>
   syslog = <%= @syslog %>
 <% end -%>
-  klipsdebug = <%= scope['::libreswan::klipsdebug'] %>
-# Do not enable debug options to debug configuration issues!
-# plutodebug "all", "none" or a combation from below:
-# "raw crypt parsing emitting control controlmore kernel pfkey
-#  natt x509 dpd dns oppo oppoinfo private".
-# Note: "private" is not included with "all", as it can show confidential
-#       information. It must be specifically specified
-# examples:
-# plutodebug="control parsing"
-# plutodebug="all crypt"
-# Again: only enable plutodebug when asked by a developer
-  plutodebug = <%= scope['::libreswan::plutodebug'] %>
+  klipsdebug = <%= @klipsdebug %>
+  # Do not enable debug options to debug configuration issues!
+  # plutodebug "all", "none" or a combination from below:
+  # "raw crypt parsing emitting control controlmore kernel pfkey
+  #  natt x509 dpd dns oppo oppoinfo private".
+  # Note: "private" is not included with "all", as it can show confidential
+  #       information. It must be specifically specified
+  # examples:
+  # plutodebug="control parsing"
+  # plutodebug="all crypt"
+  # Again: only enable plutodebug when asked by a developer
+  plutodebug = <%= @plutodebug %>
 <% if @uniqueids  then -%>
-  uniqueids = <%= @uniqueids %>
+  uniqueids = <%= @uniqueids.downcase.strip %>
 <% end -%>
 <% if @plutorestartoncrash  then -%>
-  plutorestartoncrash = <%= @plutorestartoncrash %>
+  plutorestartoncrash = <%= @plutorestartoncrash.downcase.strip %>
 <% end -%>
-# Normally, pluto logs via syslog. If you want to log to a file,
-# specify below or to disable logging, eg for embedded systems, use
-# the file name /dev/null
-# Note: SElinux policies might prevent pluto writing to a log file at
-#       an unusual location.
-<% if @plutostderrlog  then -%>
-  plutostderrlog = <%= @plutostderrlog %>
+  # Normally, pluto logs via syslog. If you want to log to a file,
+  # specify below or to disable logging, eg for embedded systems, use
+  # the file name /dev/null
+  # Note: SElinux policies might prevent pluto writing to a log file at
+  #       an unusual location.
+<% if @logfile  then -%>
+  logfile = <%= @logfile %>
+<% else -%>
+  #logfile=/var/log/pluto.log
 <% end -%>
-<% if @plutostderrlogtime  then -%>
-  plutostderrlogtime = <%= @plutostderrlogtime %>
+<% if @logappend  then -%>
+  logappend = <%= @logappend.downcase.strip %>
 <% end -%>
-<% if @force_busy  then -%>
-  force-busy = <%= @force_busy %>
+<% if @logtime  then -%>
+  logtime = <%= @logtime.downcase.strip %>
 <% end -%>
-# Enable core dumps (might require system changes, like ulimit -C)
-# This is required for abrtd to work properly
-# Note: SElinux policies might prevent pluto writing the core at
-#       unusual locations
-  dumpdir = <%= scope['::libreswan::dumpdir'] %>
+<% if @ddos_mode  then -%>
+  ddos-mode = <%= @ddos_mode %>
+<% end -%>
+<% if @ddos_ike_treshold  then -%>
+  ddos-ike-treshold = <%= @ddos_ike_treshold %>
+<% end -%>
+  # Enable core dumps (might require system changes, like ulimit -C)
+  # This is required for abrtd to work properly
+  # Note: SElinux policies might prevent pluto writing the core at
+  #       unusual locations
+  dumpdir = <%= @dumpdir %>
+<%-# Quotes are required because this may be an executable with command line options/args -%>
 <% if @statsbin  then -%>
-  statsbin = <%= @statsbin %>
+  statsbin = "<%= @statsbin %>"
 <% end -%>
-  secretsfile = <%= scope['::libreswan::secretsfile'] %>
+  secretsfile = <%= @secretsfile %>
 <% if @perpeerlog  then -%>
-  perpeerlog = <%= @perpeerlog %>
+  perpeerlog = <%= @perpeerlog.downcase.strip %>
 <% end -%>
-  perpeerlogdir = <%= scope['::libreswan::perpeerlogdir'] %>
+  perpeerlogdir = <%= @perpeerlogdir %>
 <% if @fragicmp  then -%>
-  fragicmp = <%= @fragicmp %>
+  fragicmp = <%= @fragicmp.downcase.strip %>
 <% end -%>
 <% if @hidetos  then -%>
-  hidetos = <%= @hidetos %>
+  hidetos = <%= @hidetos.downcase.strip %>
 <% end -%>
 <% if @overridemtu  then -%>
   overridemtu = <%= @overridemtu %>
 <% end -%>
-# which IPsec stack to use, "netkey" (the default), "klips" or "mast".
-# For MacOSX use "bsd"
-# protostack =  "netkey"
-  protostack = <%= scope['::libreswan::protostack'] %>
-#
-# NAT-TRAVERSAL support
-# exclude networks used on server side by adding %v4:!a.b.c.0/24
-# It seems that T-Mobile in the US and Rogers/Fido in Canada are
-# using 25/8 as "private" address space on their wireless networks.
-# This range has never been announced via BGP (at least upto 2015)
-#	virtual_private=%v4:10.0.0.0/8,%v4:192.168.0.0/16,%v4:172.16.0.0/12,%v4:25.0.0.0/8,%v4:100.64.0.0/10,%v6:fd00::/8,%v6:fe80::/10
-<% if scope['::libreswan::virtual_private']  then -%>
-     <% if scope['::libreswan::virtual_private'].size > 1 then %>
-  virtual_private = %v4:<%= scope['::libreswan::virtual_private'].join(",%v4:")%>
-     <% else %>
-  virtual_private = %v4:<%= scope['::libreswan::virtual_private'].to_s%>
-     <% end %>
+  # which IPsec stack to use, "netkey" (the default), "klips" or "mast".
+  # For MacOSX use "bsd"
+  protostack = <%= @protostack %>
+  #
+  # NAT-TRAVERSAL support
+  # exclude networks used on server side by adding %v4:!a.b.c.0/24
+  # It seems that T-Mobile in the US and Rogers/Fido in Canada are
+  # using 25/8 as "private" address space on their wireless networks.
+  # This range has never been announced via BGP (at least upto 2015)
+  #	virtual_private=%v4:10.0.0.0/8,%v4:192.168.0.0/16,%v4:172.16.0.0/12,%v4:25.0.0.0/8,%v4:100.64.0.0/10,%v6:fd00::/8,%v6:fe80::/10
+<%
+if @virtual_private
+  require 'ipaddr'
+  _virtual_private = []
+  @virtual_private.each do |net|
+    prefix = ''
+    if net.start_with?('!')
+      prefix = '!'
+      net = net[1..-1]
+    end
+    begin
+      ip = IPAddr.new(net)
+      if (ip.ipv4?)
+        _virtual_private << "%v4:#{prefix}#{net}"
+      elsif (ip.ipv6?)
+        _virtual_private << "%v6:#{prefix}#{net}"
+      end
+    rescue
+      raise Puppet::ParseError.new("#{net} in virtual_private is not an IPv4/IPv6 address")
+    end
+  end
+end
+-%>
+<% if _virtual_private  then -%>
+  virtual-private = <%= _virtual_private.join(',')%>
 <% end -%>
 #
 # You must add your IPsec connections as separate files in the ipsecdir
 #  (defined above (default /etc/ipsec.d/ )
-include <%= scope['::libreswan::ipsecdir'] %>/*.conf
+include <%= @ipsecdir %>/*.conf

--- a/templates/etc/ipsec.d/connection.conf.erb
+++ b/templates/etc/ipsec.d/connection.conf.erb
@@ -1,5 +1,6 @@
+<%-# TODO order settings more logically -%>
 conn <%= @conn_name %>
-#Left Side Settings
+# Left Side Settings
 <% if @left then -%>
   left = <%= @left %>
 <% end -%>
@@ -13,7 +14,7 @@ conn <%= @conn_name %>
   leftcert = <%= @leftcert %>
 <% end -%>
 <% if @leftca then -%>
-  leftca = <%= @lefta %>
+  leftca = <%= @leftca %>
 <% end -%>
 <% if @leftprotoport then -%>
   leftprotoport = <%= @leftprotoport %>
@@ -30,7 +31,35 @@ conn <%= @conn_name %>
 <% if @leftsendcert then -%>
   leftsendcert = <%= @leftsendcert %>
 <% end -%>
-#Right Side Settings
+<% if @leftsubnet then -%>
+  leftsubnet = <%= @leftsubnet %>
+<% end -%>
+<% if @leftsubnets then -%>
+  leftsubnets = {<%= @leftsubnets.join(' ') %>}
+<% end -%>
+<% if @leftnexthop then -%>
+  leftnexthop = <%= @leftnexthop %>
+<% end -%>
+<% if @leftaddresspool then -%>
+  leftaddresspool = <%= @leftaddresspool.join('-') %>
+<% end -%>
+<% if @leftxauthserver then -%>
+  leftxauthserver = <%= @leftxauthserver.downcase.strip %>
+<% end -%>
+<% if @leftxauthusername then -%>
+  leftxauthusername = <%= @leftxauthusername %>
+<% end -%>
+<% if @leftxauthclient then -%>
+  leftxauthclient = <%= @leftxauthclient.downcase.strip %>
+<% end -%>
+<% if @leftmodecfgserver then -%>
+  leftmodecfgserver = <%= @leftmodecfgserver.downcase.strip %>
+<% end -%>
+<% if @leftmodecfgclient then -%>
+  leftmodecfgclient = <%= @leftmodecfgclient.downcase.strip %>
+<% end -%>
+
+# Right Side Settings
 <% if @right then -%>
   right = <%= @right %>
 <% end -%>
@@ -61,7 +90,38 @@ conn <%= @conn_name %>
 <% if @rightsendcert then -%>
   rightsendcert = <%= @rightsendcert %>
 <% end -%>
-# Universal settings
+<% if @rightsubnet then -%>
+  rightsubnet = <%= @rightsubnet %>
+<% end -%>
+<% if @rightsubnets then -%>
+  rightsubnets = {<%= @rightsubnets.join(' ') %>}
+<% end -%>
+<% if @rightnexthop then -%>
+  rightnexthop = <%= @rightnexthop %>
+<% end -%>
+<% if @rightaddresspool then -%>
+  rightaddresspool = <%= @rightaddresspool.join('-') %>
+<% end -%>
+<% if @rightxauthserver then -%>
+  rightxauthserver = <%= @rightxauthserver.downcase.strip %>
+<% end -%>
+<% if @rightxauthusername then -%>
+  rightxauthusername = <%= @rightxauthusername %>
+<% end -%>
+<% if @rightxauthclient then -%>
+  rightxauthclient = <%= @rightxauthclient.downcase.strip %>
+<% end -%>
+<% if @rightmodecfgserver then -%>
+  rightmodecfgserver = <%= @rightmodecfgserver.downcase.strip %>
+<% end -%>
+<% if @rightmodecfgclient then -%>
+  rightmodecfgclient = <%= @rightmodecfgclient.downcase.strip %>
+<% end -%>
+
+# Universal Settings
+<% if @connaddrfamily then -%>
+  connaddrfamily = <%= @connaddrfamily %>
+<% end -%>
 <% if @authby then -%>
   authby = <%= @authby %>
 <% end -%>
@@ -87,52 +147,19 @@ conn <%= @conn_name %>
   sareftrack = <%= @sareftrack %>
 <% end -%>
 <% if @narrowing then -%>
-  narrowing = <%= @narrowing %>
+  narrowing = <%= @narrowing.downcase.strip %>
 <% end -%>
-<% if @ikevpad then -%>
-  ikevpad = <%= @ikevpad %>
+<% if @ikepad then -%>
+  ikepad = <%= @ikepad.downcase.strip %>
 <% end -%>
-<% if @ike_frag then -%>
-  ikev-frag = <%= @ikev_frag %>
+<% if @fragmentation then -%>
+  fragmentation = <%= @fragmentation %>
 <% end -%>
 <% if @sha2_truncbug then -%>
-  sha2-truncbug = <%= @sha2_truncbug %>
+  sha2-truncbug = <%= @sha2_truncbug.downcase.strip %>
 <% end -%>
 <% if @nat_ikev1_method then -%>
   nat-ikev1-method = <%= @nat_ikev1_method %>
-<% end -%>
-<% if @leftaddresspool then -%>
-  leftaddresspool = <%= @leftaddresspool %>
-<% end -%>
-<% if @rightaddresspool then -%>
-  rightaddresspool = <%= @rightaddresspool %>
-<% end -%>
-<% if @leftxauthserver then -%>
-  leftxauthserver = <%= @leftxauthserver %>
-<% end -%>
-<% if @rightxauthserver then -%>
-  rightxauthserver = <%= @rightxauthserver %>
-<% end -%>
-<% if @leftxauthusername then -%>
-  leftxauthusername = <%= @leftxauthusername %>
-<% end -%>
-<% if @rightxauthusername then -%>
-  rightxauthusername = <%= @rightxauthusername %>
-<% end -%>
-<% if @leftauthclient then -%>
-  leftauthclient = <%= @leftauthclient %>
-<% end -%>
-<% if @rightxauthclient then -%>
-  rightxauthclient = <%= @rightxauthclient %>
-<% end -%>
-<% if @leftmodecfgserver then -%>
-  leftmodecfgserver = <%= @leftmodecfgserver %>
-<% end -%>
-<% if @rightmodecfgserver then -%>
-  rightmodecfgserver = <%= @rightmodecfgserver %>
-<% end -%>
-<% if @leftmodecfgclient then -%>
-  leftmodecfgclient = <%= @leftmodecfgclient %>
 <% end -%>
 <% if @xauthby then -%>
   xauthby = <%= @xauthby %>
@@ -141,7 +168,7 @@ conn <%= @conn_name %>
   xauthfail = <%= @xauthfail %>
 <% end -%>
 <% if @modecfgpull then -%>
-  modecfgpull = <%= @modecfgpull %>
+  modecfgpull = <%= @modecfgpull.downcase.strip %>
 <% end -%>
 <% if @modecfgdns1 then -%>
   modecfgdns1 = <%= @modecfgdns1 %>
@@ -154,4 +181,7 @@ conn <%= @conn_name %>
 <% end -%>
 <% if @modecfgbanner then -%>
   modecfgbanner = <%= @modecfgbanner %>
+<% end -%>
+<% if @keyingtries then -%>
+  keyingtries = <%= @keyingtries %>
 <% end -%>


### PR DESCRIPTION
- Fixed several bugs in the following categories
  - Use of wrong variables (cut and paste errors or typos)
  - Improper parameter validations
  - Parameters not being used in erb files.
  - OBE names of ipsec settings.
  - Missing quotes/braces around settings that can contain whitespace
- Exposed more ipsec settings.
- Allow IPv6 addresses

SIMP-1671 #comment  1 of 2
