### PR TITLE
(SIMP-5301) updated $app_pki_external_source type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 3.1.0-0
+- Updated $app_pki_external_source to accept any string. This matches the
+  functionality of pki::copy.
+
 * Fri Jul 06 2018 Trevor Vaughan <tvaughan@onyxpont.com> - 3.1.0-0
 - Added Puppet 5 and OEL support
 

--- a/manifests/config/pki.pp
+++ b/manifests/config/pki.pp
@@ -36,7 +36,7 @@
 #   Path and name of the CA.
 #
 class libreswan::config::pki(
-  Stdlib::Absolutepath            $app_pki_external_source  = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
+  String                          $app_pki_external_source  = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath            $app_pki_dir              = '/etc/pki/simp_apps/libreswan/x509',
   Stdlib::Absolutepath            $app_pki_cert             = "${app_pki_dir}/public/${::fqdn}.pub",
   Stdlib::Absolutepath            $app_pki_key              = "${app_pki_dir}/private/${::fqdn}.pem",


### PR DESCRIPTION
- Updated $app_pki_external_source to accept any string. This matches the
  functionality of pki::copy.

SIMP-5296 #comment Updated libreswan
SIMP-5301 #close