### PR TITLE
(SIMP-5703) Fix OEL Acceptance Tests

### DIFF
--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -15,6 +15,7 @@ HOSTS:
       - default
     platform:   el-7-x86_64
     box:        onyxpoint/oel-7-x86_64
+    box_version: ">= 0.2.0"
     hypervisor: <%= hypervisor %>
   right7:
     roles:
@@ -24,6 +25,7 @@ HOSTS:
       - libreswan
     platform:   el-7-x86_64
     box:        onyxpoint/oel-7-x86_64
+    box_version: ">= 0.2.0"
     hypervisor: <%= hypervisor %>
   left6:
     roles:
@@ -33,6 +35,7 @@ HOSTS:
       - libreswan
     platform:   el-6-x86_64
     box:        onyxpoint/oel-6-x86_64
+    box_version: ">= 0.2.0"
     hypervisor: <%= hypervisor %>
   right6:
     roles:
@@ -42,6 +45,7 @@ HOSTS:
       - libreswan
     platform:   el-6-x86_64
     box:        onyxpoint/oel-6-x86_64
+    box_version: ">= 0.2.0"
     hypervisor: <%= hypervisor %>
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -55,7 +55,7 @@ end
 test_name 'libreswan class'
 
 ['6', '7'].each do |os_major_version|
-  describe "libreswan class for CentOS #{os_major_version}" do
+  describe "libreswan class for EL #{os_major_version}" do
     let(:left) { only_host_with_role( hosts, "left#{os_major_version}" ) }
     let(:right) { only_host_with_role( hosts, "right#{os_major_version}" ) }
     let(:haveged) { "package { 'epel-release': ensure => installed, provider => 'rpm', source => \"https://dl.fedoraproject.org/pub/epel/epel-release-latest-#{os_major_version}.noarch.rpm\" } -> class { 'haveged': }" }
@@ -271,6 +271,11 @@ EOM
           "        content => '-A LOCAL-INPUT -p tcp --dport #{nc_port} -j ACCEPT',\n" +
           "        apply_to => 'all',\n" +
           "        order => 11\n" +
+          "      }\n" +
+          "      iptables::listen::tcp_stateful { 'allow_sshd':\n" +
+          "        order => 8,\n" +
+          "        trusted_nets => ['ALL'],\n" +
+          "        dports => 22,\n" +
           "      }\n"
         }
         let(:rightconnection_with_firewall) { rightconnection +
@@ -284,6 +289,11 @@ EOM
           "        content => '-A LOCAL-INPUT -p tcp --dport #{nc_port} -j ACCEPT',\n" +
           "        apply_to => 'all',\n" +
           "        order => 11\n" +
+          "      }\n" +
+          "      iptables::listen::tcp_stateful { 'allow_sshd':\n" +
+          "        order => 8,\n" +
+          "        trusted_nets => ['ALL'],\n" +
+          "        dports => 22,\n" +
           "      }\n"
         }
 


### PR DESCRIPTION
- Updated oel-6-x86_64 base box to align firewall config with
  centos/6 base box
- Added ssh firewall configuration for acceptance tests that
  configure IPTables
- Set the base box_version value to 0.2.0 minimum to require
  updates when tests run

SIMP-5703 #comment Update base box and acceptance tests
SIMP-5703 #close
SIMP-4978 #close