### PR TITLE
(SIMP-6110) Use (namespaced) simplib::passgen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.1.1-0
+- Use simplib::passgen() in lieu of passgen(), a deprecated simplib
+  Puppet 3 function.
+
 * Mon Nov 05 2018 Liz Nemsick <lnemsick-simp@gmail.com> - 3.1.0-0
 - Update badges and contribution guide URL in README.md
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,7 +118,7 @@ class libreswan (
   Boolean                                $use_certs               = true,
   Variant[Boolean,Enum['simp']]          $pki                     = simplib::lookup('simp_options::pki', {'default_value' => false }),
   Boolean                                $haveged                 = simplib::lookup('simp_options::haveged', {'default_value' => false }),
-  String                                 $nssdb_password          = passgen('nssdb_password'),
+  String                                 $nssdb_password          = simplib::passgen('nssdb_password'),
   # Possible Values in ipsec.conf file
   Optional[String]                       $myid                    = undef,
   Enum['netkey','klips','mast']          $protostack              = 'netkey',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-libreswan",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": "SIMP Team",
   "summary": "Manages IPSec VPN Tunnels",
   "license": "Apache-2.0",
@@ -31,7 +31,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.5.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Use simplib::passgen() in lieu of passgen(), a deprecated simplib
Puppet 3 function.

SIMP-6110 #comment pupmod-simp-libreswan