### PR TITLE
(SIMP-8397) Add support for Mobile VPN Clients

### DIFF
--- a/manifests/config/pki/nsspki.pp
+++ b/manifests/config/pki/nsspki.pp
@@ -3,6 +3,7 @@
 # change or when the data base is initialized.
 #
 class libreswan::config::pki::nsspki(
+  String[1] $certname = $facts['fqdn'],
 ) {
   assert_private()
   Class['libreswan::config::pki'] ~> Class['libreswan::config::pki::nsspki']
@@ -13,7 +14,7 @@ class libreswan::config::pki::nsspki(
     ensure  => file,
     owner   => root,
     mode    => '0400',
-    content => ": RSA \"${::fqdn}\"",
+    content => ": RSA \"${certname}\"",
   }
 
   $_fips = $::libreswan::fips or $facts['fips_enabled']
@@ -27,7 +28,7 @@ class libreswan::config::pki::nsspki(
     require     => File['/etc/ipsec.conf'],
   }
 
-  libreswan::nss::loadcacerts{ "CA_for_${::domain}" :
+  libreswan::nss::loadcacerts{ 'CA_for_connections' :
     cert        => $::libreswan::config::pki::app_pki_ca,
     dbdir       => $::libreswan::ipsecdir,
     token       => $::libreswan::token,
@@ -35,7 +36,7 @@ class libreswan::config::pki::nsspki(
     subscribe   => Libreswan::Nss::Init_db["NSSDB ${::libreswan::ipsecdir}"]
   }
 
-  libreswan::nss::loadcerts{ $::fqdn :
+  libreswan::nss::loadcerts{ $certname :
     dbdir       => $::libreswan::ipsecdir,
     nsspwd_file => $::libreswan::nsspassword,
     cert        => $::libreswan::config::pki::app_pki_cert,

--- a/manifests/connection.pp
+++ b/manifests/connection.pp
@@ -68,6 +68,7 @@
 # @param authby
 # @param type
 # @param ikev2
+# @param mobike
 # @param phase2
 # @param ikepad
 # @param fragmentation
@@ -87,11 +88,16 @@
 # @param xauthby
 # @param xauthfail
 # @param modecfgpull
-# @param modecfgdns1
-# @param modecfgdns2
-# @param modecfgdomain
+# @param modecfgdns Support 3.23+ DNS configuration
+# @param modecfgdns1 Support <= 3.22 domain configuration
+# @param modecfgdns2 Support <= 3.22 domain configuration
+# @param modecfgdomain Support <= 3.22 domain configuration
+# @param modecfgdomains Support 3.23+ domains configuration
 # @param modecfgbanner
 # @param nat_ikev1_method
+# @param dpddelay
+# @param dpdtimeout
+# @param dpdaction
 #
 define libreswan::connection (
   Stdlib::Absolutepath                 $dir                = '/etc/ipsec.d',
@@ -150,6 +156,7 @@ define libreswan::connection (
     'passthough','reject','drop']]     $type               = undef,
   Optional[Enum['insist','permit',
     'propose','never','yes', 'no']]    $ikev2              = undef,
+  Optional[Enum['yes', 'no']]          $mobike             = undef,
   Optional[Enum['esp', 'ah']]          $phase2             = undef,
   Optional[Enum['yes','no']]           $ikepad             = undef,
   Optional[Enum['yes','no','force']]   $fragmentation      = undef,
@@ -171,12 +178,18 @@ define libreswan::connection (
     'alwaysok']]                       $xauthby            = undef,
   Optional[Enum['hard','soft']]        $xauthfail          = undef,
   Optional[Enum['yes','no']]           $modecfgpull        = undef,
+  Optional[Array[Simplib::IP]]         $modecfgdns         = undef,
   Optional[Simplib::IP]                $modecfgdns1        = undef,
   Optional[Simplib::IP]                $modecfgdns2        = undef,
   Optional[String]                     $modecfgdomain      = undef,
+  Optional[Array[String]]              $modecfgdomains     = undef,
   Optional[String]                     $modecfgbanner      = undef,
   Optional[Enum['drafts','rfc',
     'both']]                           $nat_ikev1_method   = undef,
+  Optional[Pattern[/\d+[smh]$/]]       $dpddelay           = undef,
+  Optional[Pattern[/\d+[smh]$/]]       $dpdtimeout         = undef,
+  Optional[Enum['hold', 'clear',
+    'restart']]                        $dpdaction          = undef,
 ) {
   include 'libreswan'
 

--- a/spec/classes/config_pki_nsspki_spec.rb
+++ b/spec/classes/config_pki_nsspki_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe 'libreswan::config::pki::nsspki' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, os_facts|
+      context "on #{os}" do
+        let(:facts) do
+          os_facts
+        end
+
+        context "with default param" do
+          let(:pre_condition) {
+            "class { 'libreswan':
+              service_name => 'ipsec',
+              pki          => true,
+            }"
+          }
+
+          it { is_expected.to contain_file('/etc/ipsec.secrets').with({
+            :ensure  => 'file',
+            :owner   => 'root',
+            :mode    => '0400',
+            :content => ": RSA \"#{facts[:fqdn]}\"",
+          })}
+
+          it { is_expected.to contain_libreswan__nss__loadcerts(facts[:fqdn]).with( {
+            :dbdir       => '/etc/ipsec.d',
+            :nsspwd_file => '/etc/ipsec.d/nsspassword',
+            :cert        => "/etc/pki/simp_apps/libreswan/x509/public/#{facts[:fqdn]}.pub",
+            :key         => "/etc/pki/simp_apps/libreswan/x509/private/#{facts[:fqdn]}.pem",
+            :token       => 'NSS Certificate DB'
+          } ) }
+        end
+
+        context 'with different certname setup' do
+          let(:pre_condition) {
+            "class { 'libreswan':
+              service_name => 'ipsec',
+              pki          => true,
+            }"
+          }
+          let(:hieradata) { 'client1_data' }
+
+          it { is_expected.to contain_file('/etc/ipsec.secrets').with({
+            :ensure  => 'file',
+            :owner   => 'root',
+            :mode    => '0400',
+            :content => ": RSA \"client1\"",
+          })}
+
+          it { is_expected.to contain_libreswan__nss__loadcerts('client1').with( {
+            :dbdir       => '/etc/ipsec.d',
+            :nsspwd_file => '/etc/ipsec.d/nsspassword',
+            :cert        => "/etc/pki/simp_apps/libreswan/x509/public/client1.pub",
+            :key         => "/etc/pki/simp_apps/libreswan/x509/private/client1.pem",
+            :token       => 'NSS Certificate DB'
+          } ) }
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -57,7 +57,7 @@ describe 'libreswan' do
               :fips        => false 
             } ) }
 
-            it { is_expected.to contain_libreswan__nss__loadcacerts("CA_for_#{facts[:domain]}").with( {
+            it { is_expected.to contain_libreswan__nss__loadcacerts('CA_for_connections').with( {
               :cert        => "/etc/pki/simp_apps/libreswan/x509/cacerts/cacerts.pem",
               :dbdir       => '/etc/ipsec.d',
               :nsspwd_file => '/etc/ipsec.d/nsspassword',
@@ -89,7 +89,7 @@ describe 'libreswan' do
               :fips        => true 
             } ) }
 
-            it { is_expected.to contain_libreswan__nss__loadcacerts("CA_for_#{facts[:domain]}").with( {
+            it { is_expected.to contain_libreswan__nss__loadcacerts('CA_for_connections').with( {
               :cert        => "/etc/pki/simp_apps/libreswan/x509/cacerts/cacerts.pem",
               :dbdir       => '/etc/ipsec.d',
               :nsspwd_file => '/etc/ipsec.d/nsspassword',
@@ -122,7 +122,7 @@ describe 'libreswan' do
               :fips        => true 
             } ) }
 
-            it { is_expected.to contain_libreswan__nss__loadcacerts("CA_for_#{facts[:domain]}").with( {
+            it { is_expected.to contain_libreswan__nss__loadcacerts('CA_for_connections').with( {
               :cert        => "/etc/pki/simp_apps/libreswan/x509/cacerts/cacerts.pem",
               :dbdir       => '/etc/ipsec.d',
               :nsspwd_file => '/etc/ipsec.d/nsspassword',

--- a/spec/defines/connection_spec.rb
+++ b/spec/defines/connection_spec.rb
@@ -104,9 +104,11 @@ connection_conf_content = {
     "  xauthby = alwaysok\n" +
     "  xauthfail = soft\n" +
     "  modecfgpull = yes\n" +
+    "  modecfgdns = \"8.8.8.8 8.8.4.4\"\n" +
     "  modecfgdns1 = 8.8.8.8\n" +
     "  modecfgdns2 = 8.8.4.4\n" +
     "  modecfgdomain = test.domain\n" +
+    "  modecfgdomains = \"test.domain test2.domain\"\n" +
     "  modecfgbanner = test banner\n" +
     "  keyingtries = 5\n"
 }
@@ -216,7 +218,9 @@ describe 'libreswan::connection', :type => :define do
               :modecfgpull        => 'yes',
               :modecfgdns1        => '8.8.8.8',
               :modecfgdns2        => '8.8.4.4',
+              :modecfgdns         => ['8.8.8.8', '8.8.4.4'],
               :modecfgdomain      => 'test.domain',
+              :modecfgdomains     => ['test.domain', 'test2.domain'],
               :modecfgbanner      => 'test banner',
               :nat_ikev1_method   => 'drafts',
             })

--- a/spec/fixtures/hieradata/client1_data.yaml
+++ b/spec/fixtures/hieradata/client1_data.yaml
@@ -1,0 +1,4 @@
+---
+libreswan::config::pki::app_pki_cert: '/etc/pki/simp_apps/libreswan/x509/public/client1.pub'
+libreswan::config::pki::app_pki_key: '/etc/pki/simp_apps/libreswan/x509/private/client1.pem'
+libreswan::config::pki::nsspki::certname: 'client1'

--- a/templates/etc/ipsec.d/connection.conf.erb
+++ b/templates/etc/ipsec.d/connection.conf.erb
@@ -137,6 +137,9 @@ conn <%= @conn_name %>
 <% if @ikev2 then -%>
   ikev2 = <%= @ikev2 %>
 <% end -%>
+<% if @mobike then -%>
+  mobike = <%= @mobike %>
+<% end -%>
 <% if @phase2 then -%>
   phase2 = <%= @phase2 %>
 <% end -%>
@@ -170,6 +173,9 @@ conn <%= @conn_name %>
 <% if @modecfgpull then -%>
   modecfgpull = <%= @modecfgpull %>
 <% end -%>
+<% if @modecfgdns then -%>
+  modecfgdns = "<%= @modecfgdns.join(' ') %>"
+<% end -%>
 <% if @modecfgdns1 then -%>
   modecfgdns1 = <%= @modecfgdns1 %>
 <% end -%>
@@ -179,9 +185,21 @@ conn <%= @conn_name %>
 <% if @modecfgdomain then -%>
   modecfgdomain = <%= @modecfgdomain %>
 <% end -%>
+<% if @modecfgdomains then -%>
+  modecfgdomains = "<%= @modecfgdomains.join(' ') %>"
+<% end -%>
 <% if @modecfgbanner then -%>
   modecfgbanner = <%= @modecfgbanner %>
 <% end -%>
 <% if @keyingtries then -%>
   keyingtries = <%= @keyingtries %>
+<% end -%>
+<% if @dpddelay then -%>
+  dpddelay = <%= @dpddelay %>
+<% end -%>
+<% if @dpdtimeout then -%>
+  dpdtimeout = <%= @dpdtimeout %>
+<% end -%>
+<% if @dpdaction then -%>
+  dpdaction = <%= @dpdaction %>
 <% end -%>


### PR DESCRIPTION
This updates the options available for IPsec connections to include settings
for mobike (RFC-4555), as well as updated settings for DNS and domains for
updates made to libreswan in 3.23+ versions.

This also includes updates to the NSSDB generation to allow for non-FQDN cert
names to be passed through and a generic CA title, not tied to domain, as
mobile clients will likely be using DHCP and subsequent resolv and domain
settings.

SIMP-8397 #close #comment