### PR TITLE
(SIMP-MAINT) libreswan Remove whitespace in CHANGELOG entry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,12 +2,12 @@
 - Removed obsolete configuration options whose presence prevent the
   ipsec service from starting on EL8. The corresponding deprecated
   parameters are as follows:
-  - `libreswan::ikeport` 
-  - `libreswan::nat_ikeport` 
+  - `libreswan::ikeport`
+  - `libreswan::nat_ikeport`
   - `libreswan::klipsdebug`
   - `libreswan::perpeerlog`
   - `libreswan::perpeerlogdir`
-  
+
 * Tue Jun 15 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.5.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib


### PR DESCRIPTION
Remove whitespace introduced when the CHANGELOG was edited
via the GitHub online editor.