### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.6.0
+- Add RockyLinux 8 support
+
 * Tue Jun 22 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.5.0
 - Removed obsolete configuration options whose presence prevent the
   ipsec service from starting on EL8. The corresponding deprecated

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/manifests/config/pki.pp
+++ b/manifests/config/pki.pp
@@ -20,8 +20,8 @@
 class libreswan::config::pki(
   String               $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath $app_pki_dir             = '/etc/pki/simp_apps/libreswan/x509',
-  Stdlib::Absolutepath $app_pki_cert            = "${app_pki_dir}/public/${facts['facts['networking']['fqdn']']}.pub",
-  Stdlib::Absolutepath $app_pki_key             = "${app_pki_dir}/private/${facts['facts['networking']['fqdn']']}.pem",
+  Stdlib::Absolutepath $app_pki_cert            = "${app_pki_dir}/public/${facts['networking']['fqdn']}.pub",
+  Stdlib::Absolutepath $app_pki_key             = "${app_pki_dir}/private/${facts['networking']['fqdn']}.pem",
   Stdlib::Absolutepath $app_pki_ca              = "${app_pki_dir}/cacerts/cacerts.pem"
 ){
 

--- a/manifests/config/pki.pp
+++ b/manifests/config/pki.pp
@@ -20,8 +20,8 @@
 class libreswan::config::pki(
   String               $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath $app_pki_dir             = '/etc/pki/simp_apps/libreswan/x509',
-  Stdlib::Absolutepath $app_pki_cert            = "${app_pki_dir}/public/${::fqdn}.pub",
-  Stdlib::Absolutepath $app_pki_key             = "${app_pki_dir}/private/${::fqdn}.pem",
+  Stdlib::Absolutepath $app_pki_cert            = "${app_pki_dir}/public/${facts['facts['networking']['fqdn']']}.pub",
+  Stdlib::Absolutepath $app_pki_key             = "${app_pki_dir}/private/${facts['facts['networking']['fqdn']']}.pem",
   Stdlib::Absolutepath $app_pki_ca              = "${app_pki_dir}/cacerts/cacerts.pem"
 ){
 

--- a/manifests/config/pki/nsspki.pp
+++ b/manifests/config/pki/nsspki.pp
@@ -6,7 +6,7 @@
 #   The name of the certificate to be used
 #
 class libreswan::config::pki::nsspki(
-  String[1] $certname = $facts['fqdn'],
+  String[1] $certname = $facts['networking']['fqdn'],
 ) {
   assert_private()
   Class['libreswan::config::pki'] ~> Class['libreswan::config::pki::nsspki']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -191,7 +191,7 @@ class libreswan (
   Optional[Array[Simplib::IP::V4::CIDR]] $clear_cidrs         = undef,
   Optional[Array[Simplib::IP::V4::CIDR]] $clear_private_cidrs = undef,
   Optional[Array[Simplib::IP::V4::CIDR]] $private_cidrs       = undef,
-  Optional[Array[Simplib::IP::V4::CIDR]] $private_clear_cidrs = ['0.0.0.0/0']
+  Array[Simplib::IP::V4::CIDR] $private_clear_cidrs = ['0.0.0.0/0']
 
 ) {
 

--- a/manifests/nss/init_db.pp
+++ b/manifests/nss/init_db.pp
@@ -41,11 +41,11 @@ define libreswan::nss::init_db(
     }
   }
 
-  if $facts['facts['os']['name']'] in ['RedHat', 'CentOS', 'OracleLinux', 'Rocky'] {
+  if $facts['os']['name'] in ['RedHat', 'CentOS', 'OracleLinux', 'Rocky'] {
     $init_command    = '/sbin/ipsec initnss'
   }
   else {
-    fail("Operating System '${facts['facts['os']['name']']}' is not supported by ${module_name}")
+    fail("Operating System '${facts['os']['name']}' is not supported by ${module_name}")
   }
 
   exec { "init_nssdb ${dbdir}":

--- a/manifests/nss/init_db.pp
+++ b/manifests/nss/init_db.pp
@@ -41,11 +41,11 @@ define libreswan::nss::init_db(
     }
   }
 
-  if $operatingsystem in ['RedHat', 'CentOS', 'OracleLinux', 'Rocky'] {
+  if $facts['facts['os']['name']'] in ['RedHat', 'CentOS', 'OracleLinux', 'Rocky'] {
     $init_command    = '/sbin/ipsec initnss'
   }
   else {
-    fail("Operating System '${::operatingsystem}' is not supported by ${module_name}")
+    fail("Operating System '${facts['facts['os']['name']']}' is not supported by ${module_name}")
   }
 
   exec { "init_nssdb ${dbdir}":

--- a/manifests/nss/init_db.pp
+++ b/manifests/nss/init_db.pp
@@ -41,7 +41,7 @@ define libreswan::nss::init_db(
     }
   }
 
-  if $operatingsystem in ['RedHat', 'CentOS', 'OracleLinux'] {
+  if $operatingsystem in ['RedHat', 'CentOS', 'OracleLinux', 'Rocky'] {
     $init_command    = '/sbin/ipsec initnss'
   }
   else {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-libreswan",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "author": "SIMP Team",
   "summary": "Manages IPSec VPN Tunnels",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "simp/iptables",
@@ -57,6 +57,12 @@
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
         "8"
       ]
     }


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.