### PR TITLE
Add AlmaLinux 8 support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+* Wed Sep 06 2023 Steven Pritchard <steve@sicura.us> - 3.7.0
+- Add AlmaLinux 8 support
+- Move `$init_command` in `libreswan::nss::init_db` to a parameter and set
+  the default in Hiera to avoid the hard-coded list of supported operating
+  systems
+- Clean up for puppet-lint in `libreswan::nss::init_db`
+- Add support for Puppet 8 and stdlib 9
+- Drop support for Puppet 6
+- Update gem dependencies
+- Clean up Gemfile for rubocop
+
 * Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.6.0
 - Add RockyLinux 8 support
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,28 +4,28 @@
 # This file is automatically updated as part of a puppet module baseline.
 # The next baseline sync will overwrite any local changes made to this file.
 # ------------------------------------------------------------------------------
-gem_sources = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
+gem_sources = ENV.fetch('GEM_SERVERS', 'https://rubygems.org').split(%r{[, ]+})
 
 ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 7'
-  major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
-  gem 'rake'
+  puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 7', '< 9'])
+  major_puppet_version = Array(puppet_version).first.scan(%r{(\d+)(?:\.|\Z)}).flatten.first.to_i
+  gem 'hiera-puppet-helper'
+  gem 'metadata-json-lint'
+  gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem('pdk', ENV.fetch('PDK_VERSION', ['>= 2.0', '< 4.0']), require: false) if major_puppet_version > 5
   gem 'puppet', puppet_version
+  gem 'puppetlabs_spec_helper'
+  gem 'puppet-lint-trailing_comma-check', require: false
+  gem 'puppet-strings'
+  gem 'rake'
   gem 'rspec'
   gem 'rspec-puppet'
-  gem 'hiera-puppet-helper'
-  gem 'puppetlabs_spec_helper'
-  gem 'metadata-json-lint'
-  gem 'puppet-strings'
-  gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
-  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']
-  gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false) if major_puppet_version > 5
-  gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.21.0', '< 6'])
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 3.7')
 end
 
 group :development do
@@ -35,21 +35,21 @@ group :development do
 end
 
 group :system_tests do
+  gem 'bcrypt_pbkdf'
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.28.0', '< 2']
-  gem 'bcrypt_pbkdf'
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.32.1', '< 2'])
 end
 
 # Evaluate extra gemfiles if they exist
 extra_gemfiles = [
-  ENV['EXTRA_GEMFILE'] || '',
+  ENV.fetch('EXTRA_GEMFILE', ''),
   "#{__FILE__}.project",
   "#{__FILE__}.local",
   File.join(Dir.home, '.gemfile'),
 ]
 extra_gemfiles.each do |gemfile|
   if File.file?(gemfile) && File.readable?(gemfile)
-    eval(File.read(gemfile), binding)
+    eval(File.read(gemfile), binding) # rubocop:disable Security/Eval
   end
 end

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1369,6 +1369,7 @@ The following parameters are available in the `libreswan::nss::init_db` defined 
 * [`fips`](#-libreswan--nss--init_db--fips)
 * [`token`](#-libreswan--nss--init_db--token)
 * [`nsspassword`](#-libreswan--nss--init_db--nsspassword)
+* [`init_command`](#-libreswan--nss--init_db--init_command)
 
 ##### <a name="-libreswan--nss--init_db--dbdir"></a>`dbdir`
 
@@ -1402,7 +1403,7 @@ Data type: `Boolean`
 
 
 
-Default value: `simplib::lookup('simp_options::fips', { 'default_value' => false})`
+Default value: `simplib::lookup('simp_options::fips', { 'default_value' => false })`
 
 ##### <a name="-libreswan--nss--init_db--token"></a>`token`
 
@@ -1419,6 +1420,14 @@ Data type: `Stdlib::Absolutepath`
 
 
 Default value: `"${dbdir}/nsspassword"`
+
+##### <a name="-libreswan--nss--init_db--init_command"></a>`init_command`
+
+Data type: `Optional[String[1]]`
+
+Command used to create the cert db.
+
+Default value: `simplib::lookup('libreswan::nss::init_db::init_command', { 'default_value' => undef })`
 
 ### <a name="libreswan--nss--loadcacerts"></a>`libreswan::nss::loadcacerts`
 

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,3 +1,4 @@
 ---
 libreswan::service_name: ipsec
 libreswan::package_name: libreswan
+libreswan::nss::init_db::init_command: '/sbin/ipsec initnss'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-libreswan",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "author": "SIMP Team",
   "summary": "Manages IPSec VPN Tunnels",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 8.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 10.0.0"
     },
     {
       "name": "simp/iptables",
@@ -65,12 +65,18 @@
       "operatingsystemrelease": [
         "8"
       ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8"
+      ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.22.1 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ]
 }


### PR DESCRIPTION
* Move `$init_command` in `libreswan::nss::init_db` to a parameter and set the default in Hiera to avoid the hard-coded list of supported operating systems
* Clean up for puppet-lint in `libreswan::nss::init_db`
* Add support for Puppet 8 and stdlib 9
* Drop support for Puppet 6
* Update gem dependencies
* Clean up Gemfile for rubocop